### PR TITLE
Hotfix: Fix currentYear undefined error in water bills payment

### DIFF
--- a/backend/services/waterPaymentsService.js
+++ b/backend/services/waterPaymentsService.js
@@ -82,7 +82,7 @@ class WaterPaymentsService {
       // No bills to pay - entire amount goes to credit (like HOA overpayment)
       const newCreditBalance = currentCreditBalance + amount;
       
-      await this._updateCreditBalance(clientId, unitId, currentYear, {
+      await this._updateCreditBalance(clientId, unitId, fiscalYear, {
         newBalance: newCreditBalance,
         changeAmount: amount,
         changeType: 'water_overpayment',
@@ -203,7 +203,7 @@ class WaterPaymentsService {
     console.log(`💰 Credit calculation: Used $${creditUsed}, Overpaid $${overpayment}, New balance $${newCreditBalance}`);
     
     // STEP 6: Update credit balance via HOA module
-    await this._updateCreditBalance(clientId, unitId, currentYear, {
+    await this._updateCreditBalance(clientId, unitId, fiscalYear, {
       newBalance: newCreditBalance,
       changeAmount: overpayment > 0 ? overpayment : -creditUsed,
       changeType: overpayment > 0 ? 'water_overpayment' : 'water_credit_used',


### PR DESCRIPTION
## Summary
Emergency fix for critical production blocker where water bills payment was failing with `currentYear is not defined` error.

## Problem
Water bills payment completely broken with error at line 206:
```
ReferenceError: currentYear is not defined
at WaterPaymentsService.recordPayment
```

## Root Cause
Variable `currentYear` was undefined. The correct variable `fiscalYear` was calculated at line 66-67 but incorrectly referenced as `currentYear` at lines 85 and 206.

## Solution
Changed `currentYear` → `fiscalYear` at both locations:
- Line 85: Overpayment scenario (no bills due)
- Line 206: Standard payment processing

## Testing ✅
- **Live Backend Testing:** Validated no runtime error
- **User Verification:** ✅ **User confirmed transaction saves successfully with real AVII data**
- **Coverage:** Both payment paths tested (overpayment + standard)

## Changes
- **Modified:** `backend/services/waterPaymentsService.js` (2 lines)
- **Lines Changed:** 85, 206
- **Change:** `currentYear` → `fiscalYear`

## Review Status
- ✅ Manager Review: FULLY APPROVED
- ✅ User Testing: PASSED (real AVII data)
- ✅ Fast-Track: Recommended for immediate merge

## Impact
- **Before:** Water bills payments completely broken
- **After:** Water bills payments functional
- **Risk:** Zero - surgical 2-line fix

## Related
- Fixes #21
- Emergency production blocker
- Priority 3a full implementation remains as future task