### PR TITLE
fix: Remove double centavos conversion in yearEndBalances (#124)

### DIFF
--- a/functions/backend/controllers/yearEndController.js
+++ b/functions/backend/controllers/yearEndController.js
@@ -307,7 +307,7 @@ export async function executeYearEnd(req, res) {
             .map(acc => ({
               id: acc.id,
               name: acc.name,
-              balance: pesosToCentavos(acc.balance || 0)
+              balance: acc.balance || 0  // Already in centavos, no conversion needed
             }));
           
           // Create snapshot

--- a/functions/backend/scripts/createYearEndBalanceProd.js
+++ b/functions/backend/scripts/createYearEndBalanceProd.js
@@ -4,7 +4,7 @@
  */
 import admin from 'firebase-admin';
 import { getFiscalYearBounds } from '../utils/fiscalYearUtils.js';
-import { pesosToCentavos } from '../../shared/utils/currencyUtils.js';
+
 
 const clientId = 'MTC';
 const closingYear = 2025;
@@ -44,7 +44,7 @@ async function main() {
     .map(acc => ({
       id: acc.id,
       name: acc.name,
-      balance: pesosToCentavos(acc.balance || 0)
+      balance: acc.balance || 0  // Already in centavos, no conversion needed
     }));
 
   const payload = {


### PR DESCRIPTION
## Summary
- Account balances in Firestore are already in centavos
- `pesosToCentavos()` was wrapping them again, causing 100x inflation
- Removed the wrapper in `yearEndController.js` and `createYearEndBalanceProd.js`
- Matches the correct pattern already used elsewhere in the same file (line 481)

## Test plan
- [ ] Verify existing yearEndBalances data is not affected (read-only fix)
- [ ] Next year-end close will store correct values (before AVII June 2026)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to snapshot serialization that corrects a unit conversion bug; existing stored snapshots are unaffected unless regenerated/backfilled.
> 
> **Overview**
> Year-end balance snapshot creation now **stores account balances without calling `pesosToCentavos()`**, preventing 100x inflation when balances are already stored in centavos.
> 
> This change applies both to the year-end execution path in `yearEndController.js` and the temporary production backfill script `createYearEndBalanceProd.js` (also removing the unused `pesosToCentavos` import there).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e3a02d989c9d6b39d205f33de1d17d1ecfe94d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->