### PR TITLE
refactor: Always use dual-language statement generation (#146)

### DIFF
--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -383,19 +383,11 @@ router.get('/statement/data', authenticateUserWithProfile, async (req, res) => {
     const unitId = req.query.unitId;
     const fiscalYear = req.query.fiscalYear ? parseInt(req.query.fiscalYear) : null;
     const language = req.query.language || 'english';
-    const generateBothLanguages = req.query.generateBothLanguages === 'true';
     
     if (!unitId) {
       return res.status(400).json({ 
         success: false, 
         error: 'unitId query parameter is required' 
-      });
-    }
-    
-    if (!unitId) {
-      return res.status(400).json({
-        success: false,
-        error: 'unitId query parameter is required'
       });
     }
 
@@ -411,22 +403,11 @@ router.get('/statement/data', authenticateUserWithProfile, async (req, res) => {
       }
     });
 
-    // Generate statement data (with optional dual-language support)
-    let statement;
-    if (generateBothLanguages) {
-      // Generate both languages (optimization: data fetch happens once, HTML built twice)
-      statement = await generateStatementData(api, clientId, unitId, {
-        fiscalYear,
-        language,
-        generateBothLanguages: true
-      });
-    } else {
-      // Single language (original behavior)
-      statement = await generateStatementData(api, clientId, unitId, {
-        fiscalYear,
-        language
-      });
-    }
+    // Generate statement data (always produces both languages - Issue #146)
+    const statement = await generateStatementData(api, clientId, unitId, {
+      fiscalYear,
+      language
+    });
     
     res.json({ success: true, data: statement });
   } catch (error) {


### PR DESCRIPTION
## Summary
Eliminates the single-language statement generation path. `generateStatementData()` now always calls `generateBothLanguageStatements()`, fetching data once and generating both English and Spanish HTML.

## Changes
- **statementHtmlService.js** — `generateStatementData()` reduced from ~115 to ~25 lines. Always generates both languages. Returns backwards-compatible `html`/`meta` fields (set to requested language) plus `htmlEn`/`htmlEs`/`metaEn`/`metaEs`.
- **emailService.js** — `generateAndUploadPdfs()` now calls `generateStatementData()` once instead of twice. `sendStatementEmail()` fallback reuses generated HTML instead of re-fetching.
- **routes/reports.js** — `/statement/data` endpoint simplified, removed redundant branching.

## Impact
- 3 files changed, +80/-154 lines (net -74 lines removed)
- Data fetch reduced from 2x to 1x for email/PDF generation
- All existing API endpoints unchanged (backwards compatible)

## Test plan
- [ ] Statement preview (single language) — should still work via `html` field
- [ ] Statement email — verify both English and Spanish PDFs generated
- [ ] Statement PDF download — verify both languages work
- [ ] Bulk statement generation — verify no regressions
- [ ] Backend starts without errors


Made with [Cursor](https://cursor.com)