### PR TITLE
feat: add NRM1 unit owner UID migration script

### DIFF
--- a/functions/backend/scripts/migrateUnitOwnersToUIDs.js
+++ b/functions/backend/scripts/migrateUnitOwnersToUIDs.js
@@ -129,7 +129,7 @@ function convertContactArray({
         `${unitRef} ${role}[${index}] missing email; kept legacy entry`
       );
       unmatched += 1;
-      return normalizedEntry;
+      return entry;
     }
 
     if (duplicateEmailMap.has(email)) {
@@ -146,7 +146,7 @@ function convertContactArray({
         email,
         reason: `multiple users: ${duplicateUids.join(', ')}`,
       });
-      return normalizedEntry;
+      return entry;
     }
 
     const matchedUid = emailToUidMap.get(email);
@@ -161,7 +161,7 @@ function convertContactArray({
         email,
         reason: 'not found',
       });
-      return normalizedEntry;
+      return entry;
     }
 
     matched += 1;
@@ -405,6 +405,7 @@ async function main() {
       console.log('MIGRATION EXECUTION COMPLETE.');
     }
     console.log('');
+    process.exit(0);
   } catch (error) {
     console.error('Fatal migration error:', error);
     process.exit(1);


### PR DESCRIPTION
## Summary
- add `functions/backend/scripts/migrateUnitOwnersToUIDs.js` for Sprint NRM NRM1
- migrate legacy `owners/managers` entries from `{name,email}` to `{userId}` by matching emails in `users`
- support `--prod`/`--dev`, dry-run default, `--execute` write mode, `creditBalances*` skips, and unmatched email gap reporting

## Test plan
- [x] `bash scripts/pre-pr-checks.sh main` (no frontend changes detected)
- [x] `node functions/backend/scripts/migrateUnitOwnersToUIDs.js` (dev dry-run)
- [x] `node functions/backend/scripts/migrateUnitOwnersToUIDs.js --prod` (prod dry-run via ADC)
- [ ] `node functions/backend/scripts/migrateUnitOwnersToUIDs.js --prod --execute` (run after review approval)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a Firestore migration script that can update many `clients/*/units/*` documents in production when run with `--execute`, so mistakes in email matching or deployment/operator usage could cause broad data changes.
> 
> **Overview**
> Adds a new backend script, `functions/backend/scripts/migrateUnitOwnersToUIDs.js`, to migrate unit `owners`/`managers` arrays from legacy `{name,email}` entries to normalized `{userId}` references by matching emails against the `users` collection.
> 
> The script supports *dry-run by default* with `--execute` to write updates, `--prod` to use ADC against the prod project, skips `creditBalances*` unit docs, only updates fields that actually changed, and prints a summary plus an unmatched-email gap report (including duplicate-email collisions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d695e411fc4dfdd433af4c473b89f47287772d57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->