### PR TITLE
fix(auth): unify system scheduler account guard across auth + user management

### DIFF
--- a/functions/backend/controllers/userManagementController.js
+++ b/functions/backend/controllers/userManagementController.js
@@ -10,6 +10,7 @@ import { getDb } from '../firebase.js';
 import admin from 'firebase-admin';
 import { writeAuditLog } from '../utils/auditLogger.js';
 import { validateClientAccess, sanitizeUserData } from '../utils/securityUtils.js';
+import { isSystemSchedulerAccount } from '../utils/systemSchedulerAccount.js';
 import { sendPasswordNotification } from '../services/emailService.js';
 import { getNow } from '../services/DateService.js';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
@@ -24,16 +25,6 @@ function generateSecurePassword() {
     password += chars.charAt(Math.floor(Math.random() * chars.length));
   }
   return password;
-}
-
-const SYSTEM_SCHEDULER_UID = 'system-scheduler';
-
-/** Synthetic Firebase user used by scheduled jobs (internalApiClient); not a person — no temp-password emails. */
-function isSystemSchedulerAccount(userId, userData) {
-  if (userId === SYSTEM_SCHEDULER_UID) return true;
-  if (userData?.isSystemAccount === true) return true;
-  const em = (userData?.email || '').trim().toLowerCase();
-  return em === 'system@sams.sandyland.com.mx';
 }
 
 /**

--- a/functions/backend/routes/auth.js
+++ b/functions/backend/routes/auth.js
@@ -8,6 +8,7 @@ import { getDb } from '../firebase.js';
 import admin from 'firebase-admin';
 import { sendPasswordNotification } from '../services/emailService.js';
 import { getNow } from '../services/DateService.js';
+import { isSystemSchedulerAccount } from '../utils/systemSchedulerAccount.js';
 
 const router = express.Router();
 
@@ -69,7 +70,7 @@ router.post('/reset-password', async (req, res) => {
     const userId = userDoc.exists ? userDoc.id : userQuery.docs[0].id;
 
     // Internal scheduler account — not a login identity; do not send temp passwords
-    if (userRecord.uid === 'system-scheduler' || userData.isSystemAccount === true) {
+    if (isSystemSchedulerAccount(userRecord.uid, userData)) {
       return res.status(403).json({
         error: 'Password reset is not available for this account. Contact your administrator.'
       });

--- a/functions/backend/utils/systemSchedulerAccount.js
+++ b/functions/backend/utils/systemSchedulerAccount.js
@@ -1,0 +1,15 @@
+const SYSTEM_SCHEDULER_UID = 'system-scheduler';
+const SYSTEM_SCHEDULER_EMAIL = 'system@sams.sandyland.com.mx';
+
+/**
+ * Synthetic Firebase user used by scheduled jobs (internalApiClient);
+ * not a person, so interactive login/password flows should be blocked.
+ */
+export function isSystemSchedulerAccount(userId, userData) {
+  if (userId === SYSTEM_SCHEDULER_UID) return true;
+  if (userData?.isSystemAccount === true) return true;
+  const email = (userData?.email || '').trim().toLowerCase();
+  return email === SYSTEM_SCHEDULER_EMAIL;
+}
+
+export { SYSTEM_SCHEDULER_UID, SYSTEM_SCHEDULER_EMAIL };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Align system scheduler account detection across auth and user management by reusing one shared helper.

## What changed
- Added `functions/backend/utils/systemSchedulerAccount.js`.
- Moved scheduler-account detection logic into `isSystemSchedulerAccount(userId, userData)`.
- Updated `functions/backend/routes/auth.js` to use the shared helper in `/reset-password`.
- Updated `functions/backend/controllers/userManagementController.js` to import the shared helper and removed duplicated local logic.

## Why
`auth.js` previously checked only UID + `isSystemAccount`, while `userManagementController.js` also checked hardcoded scheduler email (`system@sams.sandyland.com.mx`). Reusing the same helper ensures consistent defense-in-depth behavior.

## Validation
- `bash scripts/pre-pr-checks.sh main` (no frontend changes; script reports skipped frontend checks)
- `node --check functions/backend/utils/systemSchedulerAccount.js`
- `node --check functions/backend/routes/auth.js`
- `node --check functions/backend/controllers/userManagementController.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7824743e-2ad1-4ae7-be39-9d706680ab75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7824743e-2ad1-4ae7-be39-9d706680ab75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

