### PR TITLE
fix(users): remove dead loginEnabled from reconcile script (#266)

### DIFF
--- a/scripts/reconcile-auth-users.js
+++ b/scripts/reconcile-auth-users.js
@@ -201,7 +201,6 @@ async function runAudit() {
         email: email || null,
         displayName: userData.displayName || userData.name || '',
         globalRole: userData.globalRole || '',
-        loginEnabled: userData.loginEnabled,
         propertyAccess: userData.propertyAccess || userData.clientAccess || {},
       });
     } catch (err) {
@@ -251,14 +250,14 @@ function printSummary(result) {
   if (orphanedUsers.length > 0) {
     console.log('ORPHANED USERS (Firestore doc exists, no Firebase Auth record):');
     console.log('┌──────────────────────────────┬──────────────────────────────────────┬────────────────┬──────────────┐');
-    console.log('│ Email                        │ Doc ID (old UID)                     │ Role           │ Login        │');
+    console.log('│ Email                        │ Doc ID (old UID)                     │ Role           │ Auth record  │');
     console.log('├──────────────────────────────┼──────────────────────────────────────┼────────────────┼──────────────┤');
     for (const u of orphanedUsers) {
       const email = padRight(u.email || '(no email)', 28);
       const docId = padRight(u.docId, 36);
       const role = padRight(u.globalRole || '-', 14);
-      const login = padRight(u.loginEnabled === true ? 'enabled' : u.loginEnabled === false ? 'disabled' : 'unset', 12);
-      console.log(`│ ${email} │ ${docId} │ ${role} │ ${login} │`);
+      const authCol = padRight('none', 12);
+      console.log(`│ ${email} │ ${docId} │ ${role} │ ${authCol} │`);
     }
     console.log('└──────────────────────────────┴──────────────────────────────────────┴────────────────┴──────────────┘');
     console.log('');
@@ -333,7 +332,7 @@ async function runFix(orphanedUsers) {
   console.log('  For each orphaned user, the script will:');
   console.log('    1. Create a Firebase Auth record with the SAME UID as the Firestore doc');
   console.log('    2. Set the Auth account as DISABLED');
-  console.log('    3. Set loginEnabled = false in the Firestore document');
+  console.log('    3. Remove obsolete loginEnabled from the Firestore document (if present)');
   console.log('    4. Add reconciliation metadata to the Firestore document');
   console.log('');
   console.log(`  Target project: ${projectId}`);
@@ -379,9 +378,9 @@ async function runFix(orphanedUsers) {
         disabled: true,
       });
 
-      // Step 2: Update Firestore document
+      // Step 2: Update Firestore document (Auth disabled flag is source of truth for login access)
       await db.collection('users').doc(docId).update({
-        loginEnabled: false,
+        loginEnabled: admin.firestore.FieldValue.delete(),
         _reconciled: true,
         _reconciledAt: new Date().toISOString(),
         _reconciledBy: 'reconcile-auth-users-script',


### PR DESCRIPTION
## Summary
Addresses #266: `loginEnabled` on `/users` was misleading—nothing in active SAMS code reads it; Firebase Auth `disabled` is the real gate.

## Changes
- Orphan-user audit table shows **Auth record** (`none`) instead of the obsolete **Login** column tied to `loginEnabled`.
- `--fix` path deletes `loginEnabled` via `FieldValue.delete()` while writing reconciliation metadata (stops reintroducing the dead field).
- Console copy updated to match.

## Test evidence
- `rg loginEnabled` (excluding this script): no matches elsewhere in repo.
- `bash scripts/pre-pr-checks.sh main`: no frontend diff → script exits 0 (quality gate N/A for this change).

## Residual risk
- Legacy docs or external tooling that assumed `loginEnabled` exists would need updating (none found in-repo).

Closes #266

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because the `--fix` path now deletes the `loginEnabled` field in Firestore for reconciled users; while intended, it changes stored user documents and could affect any external tooling that still expects that field.
> 
> **Overview**
> Updates `scripts/reconcile-auth-users.js` to treat Firebase Auth’s `disabled` flag as the only login gate by removing the script’s reliance on the obsolete `/users.loginEnabled` field.
> 
> The orphaned-user audit output no longer prints a “Login” column, and the `--fix` reconciliation step now deletes `loginEnabled` from the Firestore user doc (via `FieldValue.delete()`) instead of writing `loginEnabled: false`, with console text updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eab8e00c7955d421d19094d9de0774fcade52ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->