### PR TITLE
fix(exchange): DateService for exchange rates health keys (#254)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,7 @@ import { onRequest, onCall } from 'firebase-functions/v2/https';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { setGlobalOptions } from 'firebase-functions/v2';
 import admin from 'firebase-admin';
+import { getNow, addDays, DateService } from './shared/services/DateService.js';
 
 // Import existing exchange rate functions
 import { updateExchangeRates, populateHistoricalRates } from './src/exchangeRatesUpdater.js';
@@ -172,9 +173,10 @@ export const checkExchangeRatesHealth = onRequest(
   async (req, res) => {
     try {
       const db = admin.firestore();
-      const today = new Date().toISOString().split('T')[0];
-      const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
-      
+      const dateService = new DateService({ timezone: 'America/Cancun' });
+      const today = dateService.formatForFrontend(getNow()).ISO_8601;
+      const yesterday = dateService.formatForFrontend(addDays(getNow(), -1)).ISO_8601;
+
       const [todayDoc, yesterdayDoc] = await Promise.all([
         db.collection('exchangeRates').doc(today).get(),
         db.collection('exchangeRates').doc(yesterday).get()


### PR DESCRIPTION
## Summary
Addresses #254: `checkExchangeRatesHealth` used raw `new Date()` for `today` / `yesterday` document IDs, which could disagree with Cancun calendar boundaries used elsewhere.

## Changes
- Import `getNow`, `addDays`, and `DateService` from `functions/shared/services/DateService.js`.
- Compute `YYYY-MM-DD` for today and yesterday in **America/Cancun** via `formatForFrontend(...).ISO_8601`.

## Test evidence
- Manual: confirm `functions/index.js` health handler contains no `new Date(` in the touched block.
- `bash scripts/pre-pr-checks.sh main`: no frontend changes → exits 0.

## Notes
- Exchange rate collection doc IDs are expected to align with Cancun business dates; this matches `DateService` discipline.

Closes #254

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the `checkExchangeRatesHealth` Firestore doc ID date calculation to align with Cancun timezone boundaries, affecting health check results but not write paths or rate generation.
> 
> **Overview**
> Updates `checkExchangeRatesHealth` to stop deriving `today`/`yesterday` document IDs from raw `new Date()` and instead compute `YYYY-MM-DD` via `DateService` using the `America/Cancun` timezone.
> 
> This aligns the health check’s Firestore lookups with the same business-date convention used elsewhere, reducing false unhealthy/healthy signals around timezone day boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0714ad85a6392abe70203495651eb2fd627a875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->