### PR TITLE
fix(backup): use GCLOUD_PROJECT for prod Firestore export (#273)

### DIFF
--- a/functions/backend/services/backupService.js
+++ b/functions/backend/services/backupService.js
@@ -14,28 +14,45 @@ const BUCKET_NAME = 'sams-shared-backups';
 
 /**
  * Detect current environment
+ * Cloud Functions / Cloud Run set GCLOUD_PROJECT reliably; NODE_ENV may be unset or not "production".
+ * Firestore export must target the live project ID or the Admin API returns permission errors.
  * @returns {Object} { env: 'dev'|'staging'|'prod', projectId: string }
  */
 function detectEnvironment() {
-  // Check NODE_ENV first (most reliable)
+  const gcpProject =
+    process.env.GCLOUD_PROJECT ||
+    process.env.GCP_PROJECT ||
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    '';
+
+  if (gcpProject === 'sams-sandyland-prod') {
+    return { env: 'prod', projectId: gcpProject, displayName: 'Production' };
+  }
+  if (gcpProject === 'sams-staging-6cdcd') {
+    return { env: 'staging', projectId: gcpProject, displayName: 'Staging' };
+  }
+  if (gcpProject === 'sandyland-management-system') {
+    return { env: 'dev', projectId: gcpProject, displayName: 'Development' };
+  }
+
   if (process.env.NODE_ENV === 'production') {
     return {
       env: 'prod',
-      projectId: process.env.GCLOUD_PROJECT || 'sams-sandyland-prod',
+      projectId: gcpProject || 'sams-sandyland-prod',
       displayName: 'Production'
     };
-  } else if (process.env.NODE_ENV === 'staging') {
+  }
+  if (process.env.NODE_ENV === 'staging') {
     return {
       env: 'staging',
-      projectId: process.env.GCLOUD_PROJECT || 'sams-staging-6cdcd',
+      projectId: gcpProject || 'sams-staging-6cdcd',
       displayName: 'Staging'
     };
   }
-  
-  // Development environment
+
   return {
     env: 'dev',
-    projectId: process.env.GCLOUD_PROJECT || 'sandyland-management-system',
+    projectId: gcpProject || 'sandyland-management-system',
     displayName: 'Development'
   };
 }


### PR DESCRIPTION
## Issue
Closes #273

## Summary
`backupService.detectEnvironment()` previously trusted `NODE_ENV === 'production'` first. In Cloud Functions, `NODE_ENV` may be unset so the service fell through to **dev** and used the wrong default project ID for Firestore Admin export, yielding permission errors while CLI backups (correct project) still worked.

## Change
Detect **prod/staging/dev** from `GCLOUD_PROJECT` / `GCP_PROJECT` / `GOOGLE_CLOUD_PROJECT` when they match known SAMS projects, then fall back to `NODE_ENV`.

## Test evidence
- Logic review; production verification requires deploy + SuperAdmin "Run Backup Now".
- If errors persist, grant the Functions runtime SA **Datastore Import Export Admin** on the project and write access to the backup bucket (infra).

## Pre-PR
`bash scripts/pre-pr-checks.sh main` — N/A (no frontend diff on this branch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches backup environment/project selection used for Firestore Admin exports; a mis-detection could route backups to the wrong project or fail with permissions, but the change is small and localized.
> 
> **Overview**
> Updates `backupService.detectEnvironment()` to prefer GCP-provided project ID env vars (`GCLOUD_PROJECT`/`GCP_PROJECT`/`GOOGLE_CLOUD_PROJECT`) and map known SAMS project IDs directly to `prod`/`staging`/`dev`.
> 
> Falls back to `NODE_ENV` only when the project ID isn’t recognized, and consistently uses the resolved project ID for export defaults to avoid Cloud Functions deployments incorrectly targeting the dev project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a9cf0a3bf2293b2ab58f2e11b83bdf6e6daa30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->