### PR TITLE
fix(soa): six-month water mini graph data (#260)

### DIFF
--- a/functions/backend/services/statementDataService.js
+++ b/functions/backend/services/statementDataService.js
@@ -197,8 +197,8 @@ async function getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth = 7) 
       priorReading = currentReading;
     }
     
-    // Take last 6-8 periods (most recent)
-    const recentPeriods = periods.slice(-8);
+    // Last 6 consumption periods (SoA mini graph SVG fits 6 bars; 7–8 clipped past viewBox — #260)
+    const recentPeriods = periods.slice(-6);
     
     if (recentPeriods.length === 0) {
       return null;


### PR DESCRIPTION
## Issue
Closes #260

## Summary
The SoA water bar SVG is sized for six bars; `getWaterBarsData` returned up to **eight** periods, so the rightmost month was clipped.

## Change
`periods.slice(-8)` → `periods.slice(-6)`.

## Test evidence
- Code/trace: `generateWaterBarsSvg` layout vs bar count.
- Regenerate AVII SoA PDF in staging/prod to confirm six visible months including current period.

## Pre-PR
No frontend changes on branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a single slice limit in `getWaterBarsData` to match the six-bar SoA SVG, affecting only the mini-graph data returned for water consumption.
> 
> **Overview**
> Fixes the SoA water mini bar chart data to return **exactly six** most-recent consumption periods by changing `periods.slice(-8)` to `periods.slice(-6)` in `getWaterBarsData`, preventing the rightmost months from being clipped in the SVG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2daf66b357cab1a925c990d56ac29268b9d0b408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->