### PR TITLE
fix(ui): credit balance modal header + amount entry (#223)

### DIFF
--- a/frontend/sams-ui/src/components/CreditBalanceEditEntryModal.css
+++ b/frontend/sams-ui/src/components/CreditBalanceEditEntryModal.css
@@ -68,6 +68,7 @@
 
 .credit-balance-edit-entry-modal input[type="date"],
 .credit-balance-edit-entry-modal input[type="number"],
+.credit-balance-edit-entry-modal input.credit-amount-text,
 .credit-balance-edit-entry-modal select,
 .credit-balance-edit-entry-modal textarea {
   width: 100%;
@@ -81,6 +82,7 @@
 
 .credit-balance-edit-entry-modal input[type="date"]:focus,
 .credit-balance-edit-entry-modal input[type="number"]:focus,
+.credit-balance-edit-entry-modal input.credit-amount-text:focus,
 .credit-balance-edit-entry-modal select:focus,
 .credit-balance-edit-entry-modal textarea:focus {
   outline: none;
@@ -90,6 +92,7 @@
 
 .credit-balance-edit-entry-modal input[type="date"]:disabled,
 .credit-balance-edit-entry-modal input[type="number"]:disabled,
+.credit-balance-edit-entry-modal input.credit-amount-text:disabled,
 .credit-balance-edit-entry-modal select:disabled,
 .credit-balance-edit-entry-modal textarea:disabled {
   background-color: #f8f9fa;

--- a/frontend/sams-ui/src/components/CreditBalanceEditEntryModal.jsx
+++ b/frontend/sams-ui/src/components/CreditBalanceEditEntryModal.jsx
@@ -113,6 +113,13 @@ function CreditBalanceEditEntryModal({ isOpen, onClose, unitId, entry, onUpdate 
     onClose();
   };
 
+  const handleAmountSignedDecimal = (e) => {
+    const value = e.target.value;
+    if (value === '' || value === '-' || /^-?\d*\.?\d*$/.test(value)) {
+      setAmount(value);
+    }
+  };
+
   if (!isOpen || !entry) {
     return null;
   }
@@ -172,12 +179,15 @@ function CreditBalanceEditEntryModal({ isOpen, onClose, unitId, entry, onUpdate 
           <div className="form-group">
             <label htmlFor="amount">Amount (Required):</label>
             <input
-              type="number"
+              type="text"
+              inputMode="decimal"
+              autoComplete="off"
               id="amount"
+              className="credit-amount-text"
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={handleAmountSignedDecimal}
+              onWheel={(e) => e.currentTarget.blur()}
               placeholder="Enter amount"
-              step="0.01"
               disabled={loading}
               required
             />

--- a/frontend/sams-ui/src/components/CreditBalanceEditModal.css
+++ b/frontend/sams-ui/src/components/CreditBalanceEditModal.css
@@ -85,6 +85,7 @@
 }
 
 .credit-balance-modal input[type="number"],
+.credit-balance-modal input.credit-amount-text,
 .credit-balance-modal textarea {
   width: 100%;
   padding: 10px 12px;
@@ -96,6 +97,7 @@
 }
 
 .credit-balance-modal input[type="number"]:focus,
+.credit-balance-modal input.credit-amount-text:focus,
 .credit-balance-modal textarea:focus {
   outline: none;
   border-color: #0066cc;
@@ -103,6 +105,7 @@
 }
 
 .credit-balance-modal input[type="number"]:disabled,
+.credit-balance-modal input.credit-amount-text:disabled,
 .credit-balance-modal textarea:disabled {
   background-color: #f8f9fa;
   color: #6c757d;

--- a/frontend/sams-ui/src/components/CreditBalanceEditModal.jsx
+++ b/frontend/sams-ui/src/components/CreditBalanceEditModal.jsx
@@ -209,6 +209,13 @@ function CreditBalanceEditModal({ isOpen, onClose, unitId, currentBalance, year,
     onClose();
   };
 
+  const handleAmountDigitsOnly = (e) => {
+    const value = e.target.value;
+    if (value === '' || /^\d*\.?\d*$/.test(value)) {
+      setAmount(value);
+    }
+  };
+
   // Calculate preview values based on mode
   let newBalanceValue, difference, isAdd, isRemove;
   
@@ -306,17 +313,15 @@ function CreditBalanceEditModal({ isOpen, onClose, unitId, currentBalance, year,
                   {mode === 'add' ? 'Amount to Add (Required):' : 'Amount to Remove (Required):'}
                 </label>
                 <input
-                  type="number"
+                  type="text"
+                  inputMode="decimal"
+                  autoComplete="off"
                   id="amount"
+                  className="credit-amount-text"
                   value={amount}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    console.log('[CREDIT EDIT MODAL] Amount changed:', { mode, value, currentAmount: amount });
-                    setAmount(value);
-                  }}
+                  onChange={handleAmountDigitsOnly}
+                  onWheel={(e) => e.currentTarget.blur()}
                   placeholder={mode === 'add' ? "Enter positive amount to add" : "Enter positive amount to remove"}
-                  step="0.01"
-                  min="0.01"
                   disabled={loading}
                   required
                 />

--- a/frontend/sams-ui/src/components/CreditBalanceHistoryModal.css
+++ b/frontend/sams-ui/src/components/CreditBalanceHistoryModal.css
@@ -19,6 +19,7 @@
   padding: 16px 20px;
   border-bottom: 1px solid #eaeaea;
   background-color: #0066cc !important;
+  color: #ffffff !important;
 }
 
 .credit-balance-history-modal .modal-header h3 {

--- a/frontend/sams-ui/src/components/water/WaterPaymentModal.css
+++ b/frontend/sams-ui/src/components/water/WaterPaymentModal.css
@@ -8,6 +8,32 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+.water-payment-modal .modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #eaeaea;
+}
+
+.water-payment-modal .modal-header h2 {
+  margin: 0;
+  font-size: 20px;
+  color: #0527ae;
+}
+
+.water-payment-modal .close-button {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #666;
+}
+
+.water-payment-modal .close-button:hover {
+  color: #333;
+}
+
 .credit-balance-info h3 {
   color: #2c3e50;
   margin-bottom: 8px;

--- a/frontend/sams-ui/src/views/HOADuesView.css
+++ b/frontend/sams-ui/src/views/HOADuesView.css
@@ -445,31 +445,8 @@
   flex-direction: column;
 }
 
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px 20px;
-  border-bottom: 1px solid #eaeaea;
-}
-
-.modal-header h2 {
-  margin: 0;
-  font-size: 20px;
-  color: #0527ae;
-}
-
-.close-button {
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  color: #666;
-}
-
-.close-button:hover {
-  color: #333;
-}
+/* Generic .modal-header / .close-button removed — they overrode credit-balance modals (#223).
+   Scoped modal chrome lives in each component's CSS (e.g. WaterPaymentModal.css). */
 
 .unit-selector-body {
   padding: 20px;


### PR DESCRIPTION
## Issue
Closes #223

## Summary
- Removed global `.modal-header` / `.close-button` rules from `HOADuesView.css` that leaked onto credit modals; scoped water payment modal header styles in `WaterPaymentModal.css`.
- Reinforced credit history modal header contrast.
- Add/Remove and edit-entry amount fields: `type="text"` + `inputMode="decimal"`, blur on wheel — no spinners or accidental centavo nudges.

## Test evidence
- `bash scripts/pre-pr-checks.sh main` — passed on this branch.
- Manual: open HOA Dues → Credit Balance History → Add/Remove Credit; confirm header/title/close visible; amount entry behavior.

## Pre-PR
`bash scripts/pre-pr-checks.sh main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes credit adjustment amount input handling/validation and could affect what values users can enter, though it is limited to frontend UI behavior and styling.
> 
> **Overview**
> Fixes modal styling bleed by removing generic `.modal-header` / `.close-button` rules from `HOADuesView.css` and scoping equivalent header styles into `WaterPaymentModal.css`, plus improving header contrast in the credit history modal.
> 
> Updates credit balance add/remove and edit-entry amount fields to use `type="text"` with `inputMode="decimal"`, adds regex-based input filtering (signed for edit-entry, digits-only for add/remove), and blurs on mouse wheel to prevent spinner/wheel-driven value changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd8f7237ea8dc2439a83a964727135b1a8c44d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->