### PR TITLE
fix(mobile): client-scoped admin dashboard + exchange tool (#274)

### DIFF
--- a/frontend/mobile-app/src/components/Dashboard.jsx
+++ b/frontend/mobile-app/src/components/Dashboard.jsx
@@ -11,7 +11,10 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuthStable.jsx';
 import { useClients } from '../hooks/useClients.jsx';
 import ClientSwitcher from './ClientSwitcher.jsx';
-import { isOwnerOrManager as checkIsOwnerOrManager } from '../utils/authUtils.js';
+import {
+  isOwnerOrManager as checkIsOwnerOrManager,
+  hasClientAdminForClient,
+} from '../utils/authUtils.js';
 import OwnerDashboard3Cards from './owner/OwnerDashboard3Cards.jsx';
 import AdminDashboard from './admin/AdminDashboard.jsx';
 
@@ -46,6 +49,9 @@ const Dashboard = () => {
   const isAdmin = samsUser?.globalRole === 'admin';
   const isSuperAdmin = samsUser?.globalRole === 'superAdmin';
   const isAdminOrSuperAdmin = isAdmin || isSuperAdmin;
+  const clientId = typeof currentClient === 'string' ? currentClient : currentClient?.id;
+  const isClientScopedAdmin = Boolean(clientId && hasClientAdminForClient(samsUser, clientId));
+  const showAdminDashboard = isAdminOrSuperAdmin || isClientScopedAdmin;
   const isOwnerOrManager = checkIsOwnerOrManager(samsUser);
 
   return (
@@ -68,15 +74,15 @@ const Dashboard = () => {
         </Box>
 
         {/* Owner/Manager: 3-card focused dashboard */}
-        {isOwnerOrManager && !isAdminOrSuperAdmin && (
+        {isOwnerOrManager && !showAdminDashboard && (
           <OwnerDashboard3Cards />
         )}
 
         {/* Admin: 3-card dashboard + sub-dashboard (ADM-1, ADM-2) */}
-        {isAdminOrSuperAdmin && <AdminDashboard />}
+        {showAdminDashboard && <AdminDashboard />}
 
         {/* Quick Actions for Non-Admins (legacy 8-card flow — hidden when 3-card shown) */}
-        {!isAdminOrSuperAdmin && !isOwnerOrManager && (
+        {!showAdminDashboard && !isOwnerOrManager && (
           <Box sx={{ maxWidth: 400, mx: 'auto', mt: 2 }}>
             <Button
               fullWidth

--- a/frontend/mobile-app/src/components/RoleProtectedRoute.jsx
+++ b/frontend/mobile-app/src/components/RoleProtectedRoute.jsx
@@ -4,7 +4,7 @@ import { Alert, Box } from '@mui/material';
 import { useAuth } from '../hooks/useAuthStable.jsx';
 
 const RoleProtectedRoute = ({ children, requiredRole, fallbackPath = '/' }) => {
-  const { samsUser, isAuthenticated, loading } = useAuth();
+  const { samsUser, isAuthenticated, loading, currentClient } = useAuth();
 
   if (loading) {
     return null; // Loading handled by parent components
@@ -18,8 +18,12 @@ const RoleProtectedRoute = ({ children, requiredRole, fallbackPath = '/' }) => {
   const clientAccess = samsUser?.clientAccess || samsUser?.propertyAccess;
   const hasRequiredRole = () => {
     switch (requiredRole) {
-      case 'admin':
-        return userRole === 'admin' || userRole === 'superAdmin';
+      case 'admin': {
+        if (userRole === 'admin' || userRole === 'superAdmin') return true;
+        const cid = typeof currentClient === 'string' ? currentClient : currentClient?.id;
+        if (!cid || !clientAccess) return false;
+        return clientAccess[cid]?.role === 'admin';
+      }
       case 'maintenance':
         return userRole === 'maintenance' || userRole === 'admin' || userRole === 'superAdmin';
       case 'unitOwner': {

--- a/frontend/mobile-app/src/utils/authUtils.js
+++ b/frontend/mobile-app/src/utils/authUtils.js
@@ -17,3 +17,14 @@ export function isOwnerOrManager(samsUser) {
     (access) => access.role === 'unitOwner' || access.role === 'unitManager'
   );
 }
+
+/**
+ * Client-scoped HOA administrator (not necessarily globalRole admin).
+ * Mobile must treat these users as admins for dashboard and admin routes (#274).
+ */
+export function hasClientAdminForClient(samsUser, clientId) {
+  if (!samsUser || !clientId) return false;
+  if (samsUser.globalRole === 'admin' || samsUser.globalRole === 'superAdmin') return true;
+  const clientAccess = samsUser.clientAccess || samsUser.propertyAccess || {};
+  return clientAccess[clientId]?.role === 'admin';
+}


### PR DESCRIPTION
## Issue
Closes #274

## Summary
Mobile treated only `globalRole` admin/superAdmin as admins. Users with **client-scoped** `propertyAccess`/`clientAccess` role `admin` saw the minimal non-owner dashboard and lost the exchange rates card/calculator path.

## Change
- `hasClientAdminForClient()` in `authUtils.js`
- `Dashboard.jsx`: `showAdminDashboard` includes client-scoped admins
- `RoleProtectedRoute`: `requiredRole="admin"` allows current client’s admin role

## Test evidence
- `bash scripts/pre-pr-checks.sh main` — passed.
- Manual: log in as client admin (non-global admin); confirm AdminDashboard + Calculator → `/exchange-rates`; confirm admin routes (e.g. expense entry) still gated correctly.

## Pre-PR
`bash scripts/pre-pr-checks.sh main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates role-gating logic for admin screens based on per-client access, which could inadvertently broaden or restrict access if `currentClient` or access maps are mis-shaped.
> 
> **Overview**
> Client-scoped users with `clientAccess`/`propertyAccess` role `admin` are now treated as admins in the mobile app.
> 
> This adds `hasClientAdminForClient()` and updates `Dashboard` to show `AdminDashboard` (and hide non-admin quick actions/owner cards) when the selected client grants admin access, and updates `RoleProtectedRoute` so `requiredRole="admin"` allows admin access for the current client even without a global admin role.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05ce8425e6ff617682f865e81af6498a505aad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->