### PR TITLE
fix(mobile): unify SoA stored statement UX (#251)

### DIFF
--- a/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
+++ b/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -12,7 +12,6 @@ import {
   InputLabel,
   Card,
   CardContent,
-  Divider,
 } from '@mui/material';
 import {
   Download as DownloadIcon,
@@ -20,27 +19,24 @@ import {
   FolderOpen as ArchiveIcon,
   NoteAdd as GenerateIcon,
 } from '@mui/icons-material';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
 import { useAuth } from '../../hooks/useAuthStable.jsx';
 import { useSelectedUnit } from '../../context/SelectedUnitContext.jsx';
 import { config } from '../../config/index.js';
 import { auth, db } from '../../services/firebase';
-import { getMexicoDate } from '../../utils/timezone.js';
 import { LoadingSpinner } from '../common';
+import { buildStoredStatementOptions } from '../../utils/storedStatementLabels.js';
 
 const API_BASE_URL = config.api.baseUrl;
 
-const MONTH_NAMES = [
-  '', 'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
-];
-
 const StatementPdfViewer = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
   const { currentClient, firebaseUser } = useAuth();
   const { selectedUnitId } = useSelectedUnit();
 
   const clientId = typeof currentClient === 'string' ? currentClient : currentClient?.id;
-  const currentYear = getMexicoDate().getFullYear();
 
   // Stored statements state
   const [storedStatements, setStoredStatements] = useState([]);
@@ -53,11 +49,6 @@ const StatementPdfViewer = () => {
   const [pdfSource, setPdfSource] = useState(null); // 'stored' | 'generated'
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-
-  const yearOptions = [];
-  for (let y = currentYear; y >= currentYear - 3; y--) {
-    yearOptions.push(y);
-  }
 
   // Fetch stored statement metadata from Firestore
   const fetchStoredStatements = useCallback(async () => {
@@ -108,34 +99,26 @@ const StatementPdfViewer = () => {
     };
   }, [pdfUrl, pdfSource]);
 
-  // Deduplicate by year+month+language, keeping most recent generation
-  const storedOptions = (() => {
-    const deduped = new Map();
-    for (const s of storedStatements) {
-      const langLabel = (s.language || 'english').toLowerCase() === 'spanish' ? 'ES' : 'EN';
-      const key = `${s.calendarYear}-${s.calendarMonth}-${langLabel}`;
+  const storedOptions = useMemo(
+    () => buildStoredStatementOptions(storedStatements),
+    [storedStatements]
+  );
 
-      const existing = deduped.get(key);
-      if (!existing) {
-        deduped.set(key, s);
-      } else {
-        const existingTime = existing.reportGenerated?._seconds || 0;
-        const currentTime = s.reportGenerated?._seconds || 0;
-        if (currentTime > existingTime) {
-          deduped.set(key, s);
-        }
-      }
-    }
-
-    return Array.from(deduped.values()).map((s) => {
-      const langLabel = (s.language || 'english').toLowerCase() === 'spanish' ? 'ES' : 'EN';
-      const monthName = MONTH_NAMES[s.calendarMonth] || `Month ${s.calendarMonth}`;
-      return {
-        ...s,
-        label: `${monthName} ${s.calendarYear} (${langLabel})`,
-      };
+  // My Unit → Statement: open chosen stored PDF in-app (#251)
+  useEffect(() => {
+    const openStoredId = location.state?.openStoredId;
+    if (!openStoredId || storedStatements.length === 0) return;
+    const statement = storedStatements.find((s) => s.id === openStoredId);
+    if (!statement?.storageUrl) return;
+    setSelectedStored(openStoredId);
+    setPdfUrl((prev) => {
+      if (prev && String(prev).startsWith('blob:')) URL.revokeObjectURL(prev);
+      return statement.storageUrl;
     });
-  })();
+    setPdfSource('stored');
+    setError(null);
+    navigate(location.pathname, { replace: true, state: {} });
+  }, [location.state, location.pathname, navigate, storedStatements]);
 
   const handleOpenStored = () => {
     if (!selectedStored) return;

--- a/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
+++ b/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
@@ -3,7 +3,7 @@
  * Single scrollable page: Account Summary, Payment Info, Fee Schedule, Recent Transactions, Stored Statements
  * Sprint MOBILE-OWNER-UX (MOB-3)
  */
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -32,6 +32,7 @@ import { useHoaConfig } from '../../hooks/useHoaConfig.js';
 import { db } from '../../services/firebase';
 import { getMexicoDateTime, formatDateForDisplay } from '../../utils/timezone.js';
 import { formatPesosForDisplay } from '@shared/utils/currencyUtils.js';
+import { buildStoredStatementOptions } from '../../utils/storedStatementLabels.js';
 
 const UnitSubDashboard = () => {
   const navigate = useNavigate();
@@ -73,6 +74,11 @@ const UnitSubDashboard = () => {
   useEffect(() => {
     fetchStoredStatements();
   }, [fetchStoredStatements]);
+
+  const storedStatementRows = useMemo(
+    () => buildStoredStatementOptions(storedStatements),
+    [storedStatements]
+  );
 
   if (!currentClient || !selectedUnitId) {
     return (
@@ -211,21 +217,29 @@ const UnitSubDashboard = () => {
       <Card sx={{ mb: 2, borderRadius: 2 }}>
         <CardContent>
           <Typography variant="subtitle2" color="text.secondary" gutterBottom>Statements</Typography>
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+            Each month may include English (EN) and Spanish (ES) versions.
+          </Typography>
           {storedLoading ? (
             <Box display="flex" justifyContent="center" py={1}><LoadingSpinner size="small" /></Box>
-          ) : storedStatements.length === 0 ? (
+          ) : storedStatementRows.length === 0 ? (
             <Typography variant="body2" color="text.secondary">No stored statements</Typography>
           ) : (
             <List dense disablePadding>
-              {storedStatements.slice(0, 5).map((s) => (
+              {storedStatementRows.slice(0, 5).map((s) => (
                 <ListItem key={s.id} disablePadding>
                   <ListItemText
-                    primary={`${s.calendarMonth || ''}/${s.calendarYear || ''}`}
+                    primary={s.label}
                     primaryTypographyProps={{ variant: 'body2' }}
                   />
                   {s.storageUrl && (
-                    <Button size="small" startIcon={<PdfIcon />} href={s.storageUrl} target="_blank" rel="noopener">
-                      Open
+                    <Button
+                      size="small"
+                      startIcon={<PdfIcon />}
+                      onClick={() => navigate('/statement', { state: { openStoredId: s.id } })}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      View
                     </Button>
                   )}
                 </ListItem>

--- a/frontend/mobile-app/src/utils/storedStatementLabels.js
+++ b/frontend/mobile-app/src/utils/storedStatementLabels.js
@@ -1,0 +1,45 @@
+/**
+ * Shared labels for stored Statement of Account rows (mobile PWA) — #251
+ */
+
+const MONTH_NAMES = [
+  '', 'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+export function languageSuffix(language) {
+  return (language || 'english').toLowerCase() === 'spanish' ? 'ES' : 'EN';
+}
+
+export function formatStoredStatementLabel(s) {
+  const lang = languageSuffix(s.language);
+  const m = Number(s.calendarMonth);
+  const monthName = MONTH_NAMES[m] || `Month ${s.calendarMonth}`;
+  return `${monthName} ${s.calendarYear} (${lang})`;
+}
+
+/**
+ * Deduplicate by calendar year + month + language; keep newest reportGenerated.
+ */
+export function buildStoredStatementOptions(statements) {
+  const deduped = new Map();
+  for (const s of statements || []) {
+    const lang = languageSuffix(s.language);
+    const key = `${s.calendarYear}-${s.calendarMonth}-${lang}`;
+    const existing = deduped.get(key);
+    if (!existing) {
+      deduped.set(key, s);
+      continue;
+    }
+    const existingTime = existing.reportGenerated?._seconds || 0;
+    const currentTime = s.reportGenerated?._seconds || 0;
+    if (currentTime > existingTime) deduped.set(key, s);
+  }
+  return Array.from(deduped.values())
+    .map((row) => ({ ...row, label: formatStoredStatementLabel(row) }))
+    .sort((a, b) => {
+      if (b.calendarYear !== a.calendarYear) return b.calendarYear - a.calendarYear;
+      if (b.calendarMonth !== a.calendarMonth) return b.calendarMonth - a.calendarMonth;
+      return languageSuffix(b.language).localeCompare(languageSuffix(a.language));
+    });
+}


### PR DESCRIPTION
## Issue
Closes #251

## Summary
My Unit showed `M/YYYY` only and opened PDFs in a **new tab**; More → Statement used month names + (EN)/(ES) and in-app iframe. Shared `buildStoredStatementOptions` / labels; My Unit **View** navigates to `/statement` with `state.openStoredId` so the same in-app viewer opens the stored PDF.

## Change
- `frontend/mobile-app/src/utils/storedStatementLabels.js`
- `StatementPdfViewer.jsx` — deep-link effect + shared options
- `UnitSubDashboard.jsx` — labels, caption, in-app path

## Test evidence
- `bash scripts/pre-pr-checks.sh main` — passed.
- Manual: owner PWA → My Unit → View on EN and ES rows; confirm iframe viewer and labels match More menu wording.

## Pre-PR
`bash scripts/pre-pr-checks.sh main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation change that reuses existing `/statement` viewer; main risk is minor regressions in statement selection/deduping and route state handling.
> 
> **Overview**
> Unifies the mobile owner stored-statement experience so both **My Unit** and **More → Statement** show the same month-name + language (EN/ES) labels and deduplicated statement rows.
> 
> My Unit’s stored statement action now navigates to `/statement` and opens the selected PDF in the existing in-app iframe viewer via `state.openStoredId` (instead of opening a new tab), with viewer logic updated to consume and clear that route state.
> 
> Adds a shared `storedStatementLabels.js` utility to centralize label formatting, language suffixing, sorting, and newest-per-month/language deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d70d097ad29f015867ae6337ec4482c97512fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->