### PR TITLE
fix(users): new-client access mapping for multi-client unit roles (#231)

### DIFF
--- a/frontend/sams-ui/src/components/admin/UserManagement.jsx
+++ b/frontend/sams-ui/src/components/admin/UserManagement.jsx
@@ -25,6 +25,12 @@ function getInviteUrlFromResponse(res) {
   return res?.inviteUrl || (res?.inviteToken ? `${window.location.origin}/invite/${res.inviteToken}` : null);
 }
 
+/** Merge legacy clientAccess with canonical propertyAccess (propertyAccess wins per client). */
+function mergedPropertyAccess(user) {
+  if (!user) return {};
+  return { ...(user.clientAccess || {}), ...(user.propertyAccess || {}) };
+}
+
 const UserManagement = ({ 
   onSelectionChange, 
   onItemCountChange,
@@ -327,7 +333,7 @@ const UserRow = ({ user, canManage, isSelected, onSelect, currentUser }) => {
 
   const getAllUnitAssignments = (user) => {
     const assignments = [];
-    Object.entries(user.propertyAccess || {}).forEach(([clientId, access]) => {
+    Object.entries(mergedPropertyAccess(user)).forEach(([clientId, access]) => {
       // Handle new unitAssignments structure
       if (access.unitAssignments && Array.isArray(access.unitAssignments)) {
         access.unitAssignments.forEach(assignment => {
@@ -1063,7 +1069,7 @@ const EditUserModal = ({ user, onClose, onUpdate, currentUser }) => {
     name: user?.name || '',
     isActive: user?.isActive !== false,
     globalRole: user?.globalRole || 'user',
-    propertyAccess: user?.propertyAccess || {},
+    propertyAccess: mergedPropertyAccess(user),
     // Unit assignment form fields
     newClientId: '',
     newUnitId: '',
@@ -1100,7 +1106,7 @@ const EditUserModal = ({ user, onClose, onUpdate, currentUser }) => {
         name: user.name || '',
         isActive: user.isActive !== false,
         globalRole: user.globalRole || 'user',
-        propertyAccess: user.propertyAccess || {},
+        propertyAccess: mergedPropertyAccess(user),
         newClientId: prev.newClientId, // Preserve form state
         newUnitId: prev.newUnitId,
         newRole: prev.newRole,
@@ -1167,45 +1173,38 @@ const EditUserModal = ({ user, onClose, onUpdate, currentUser }) => {
   useEffect(() => {
     const loadAvailableClients = async () => {
       try {
-        // Get unique client IDs from all user's current access
-        const clientIds = Object.keys(user.propertyAccess || {});
-        
-        // Also fetch all available clients for SuperAdmin
+        const access = mergedPropertyAccess(user);
+        const clientIdSet = new Set(Object.keys(access));
+
+        // SuperAdmin: include every registered client so new tenants appear in the picker (#231)
         if (currentUser?.email === 'michael@landesman.com' || currentUser?.globalRole === 'superAdmin') {
           try {
-            const response = await secureApi.getSystemUsers();
-            const allUsers = response.users || [];
-            const allClientIds = new Set();
-            
-            allUsers.forEach(u => {
-              Object.keys(u.propertyAccess || {}).forEach(clientId => {
-                allClientIds.add(clientId);
+            const clientsList = await secureApi.getClients();
+            if (Array.isArray(clientsList)) {
+              clientsList.forEach((c) => {
+                if (c && c.id) clientIdSet.add(c.id);
               });
-            });
-            
-            // Combine current user's clients with all system clients
-            const uniqueClients = [...new Set([...clientIds, ...Array.from(allClientIds)])];
-            setAvailableClients(uniqueClients.map(id => ({ id, name: id })));
-          } catch (error) {
-            console.log('Using user client access only');
-            setAvailableClients(clientIds.map(id => ({ id, name: id })));
+            }
+          } catch (err) {
+            console.warn('getClients failed; using access-derived client list only', err);
           }
-        } else {
-          setAvailableClients(clientIds.map(id => ({ id, name: id })));
         }
+
+        const sorted = [...clientIdSet].sort();
+        setAvailableClients(sorted.map((id) => ({ id, name: id })));
       } catch (error) {
         console.error('Failed to load available clients:', error);
         setAvailableClients([]);
       }
     };
-    
+
     loadAvailableClients();
   }, [user, secureApi, currentUser]);
 
   // Get all unit assignments for the user (copy of function from main component)
   const getAllUnitAssignments = (user) => {
     const assignments = [];
-    Object.entries(user.propertyAccess || {}).forEach(([clientId, access]) => {
+    Object.entries(mergedPropertyAccess(user)).forEach(([clientId, access]) => {
       // Handle new unitAssignments structure
       if (access.unitAssignments && Array.isArray(access.unitAssignments)) {
         access.unitAssignments.forEach(assignment => {

--- a/functions/backend/controllers/userManagementController.js
+++ b/functions/backend/controllers/userManagementController.js
@@ -28,6 +28,20 @@ function generateSecurePassword() {
 }
 
 /**
+ * Merge legacy clientAccess with canonical propertyAccess (propertyAccess wins per clientId).
+ * Avoids dropping access when persisting propertyAccess after partial migration (#231).
+ */
+function mergePropertyAccessFromUserDoc(userData) {
+  const legacy = userData?.clientAccess && typeof userData.clientAccess === 'object'
+    ? userData.clientAccess
+    : {};
+  const current = userData?.propertyAccess && typeof userData.propertyAccess === 'object'
+    ? userData.propertyAccess
+    : {};
+  return { ...legacy, ...current };
+}
+
+/**
  * Add person to unit's arrays based on their role
  * @param {FirebaseFirestore.WriteBatch} batch - Firestore batch
  * @param {string} clientId - Client ID
@@ -1056,7 +1070,7 @@ export async function addClientAccess(req, res) {
 
     const userData = userDoc.data();
     const updatedClientAccess = {
-      ...userData.propertyAccess,
+      ...mergePropertyAccessFromUserDoc(userData),
       [clientId]: {
         role: role,
         unitId: unitId || null,
@@ -1127,7 +1141,7 @@ export async function removeClientAccess(req, res) {
     }
 
     const userData = userDoc.data();
-    const updatedClientAccess = { ...userData.propertyAccess };
+    const updatedClientAccess = { ...mergePropertyAccessFromUserDoc(userData) };
     delete updatedClientAccess[clientId];
 
     await db.collection('users').doc(userId).update({
@@ -1202,7 +1216,7 @@ export async function updateUserPropertyAccess(req, res) {
     const userData = userDoc.data();
     
     // Ensure propertyAccess exists
-    const currentPropertyAccess = userData.propertyAccess || {};
+    const currentPropertyAccess = mergePropertyAccessFromUserDoc(userData);
     const currentClientAccess = currentPropertyAccess[clientId] || {};
     
     // Build update data
@@ -1300,8 +1314,8 @@ export async function addUnitRoleAssignment(req, res) {
     }
 
     const userData = userDoc.data();
-    const currentClientAccess = userData.propertyAccess || {};
-    const updatedClientAccess = JSON.parse(JSON.stringify(currentClientAccess)); // Deep copy
+    const previousAccessMap = mergePropertyAccessFromUserDoc(userData);
+    const updatedClientAccess = JSON.parse(JSON.stringify(previousAccessMap)); // Deep copy
 
     // Initialize client access if it doesn't exist
     if (!updatedClientAccess[clientId]) {
@@ -1353,7 +1367,7 @@ export async function addUnitRoleAssignment(req, res) {
     });
 
     // Sync unit assignments to unit records (for all roles: owners and managers)
-    await syncUnitAssignments(userId, currentClientAccess, updatedClientAccess);
+    await syncUnitAssignments(userId, previousAccessMap, updatedClientAccess);
 
     // Log the assignment
     await writeAuditLog({
@@ -1410,8 +1424,8 @@ export async function removeUnitRoleAssignment(req, res) {
     }
 
     const userData = userDoc.data();
-    const currentClientAccess = userData.propertyAccess || {};
-    const updatedClientAccess = JSON.parse(JSON.stringify(currentClientAccess)); // Deep copy
+    const previousAccessMap = mergePropertyAccessFromUserDoc(userData);
+    const updatedClientAccess = JSON.parse(JSON.stringify(previousAccessMap)); // Deep copy
 
     // Check if user has access to this client
     if (!updatedClientAccess[clientId]) {
@@ -1461,7 +1475,7 @@ export async function removeUnitRoleAssignment(req, res) {
     });
 
     // Sync unit assignments to unit records (for all roles: owners and managers)
-    await syncUnitAssignments(userId, currentClientAccess, updatedClientAccess);
+    await syncUnitAssignments(userId, previousAccessMap, updatedClientAccess);
 
     // Log the removal
     await writeAuditLog({
@@ -1523,8 +1537,9 @@ export async function deleteUser(req, res) {
     const userData = userDoc.data();
 
     // Clean up owner/manager references in unit records by removing all assignments.
-    if (userData.propertyAccess) {
-      await syncUnitAssignments(userId, userData.propertyAccess, {});
+    const accessForSync = mergePropertyAccessFromUserDoc(userData);
+    if (Object.keys(accessForSync).length > 0) {
+      await syncUnitAssignments(userId, accessForSync, {});
     }
 
     // Delete from Firebase Auth


### PR DESCRIPTION
## Summary
Fixes [#231](https://github.com/mlandesman/SAMS/issues/231): adding a unit owner/manager assignment for a **second client** failed to appear in practice because the Edit User client dropdown only listed clients inferred from existing user mappings (and other users), so **brand-new clients** never appeared. Backend merges also read only `propertyAccess`, which could drop legacy `clientAccess` keys when writing the updated map.

## Changes
- **UI (SuperAdmin Edit User):** Build the client picker from `mergedPropertyAccess(user)` plus `GET /clients` (all registered clients) instead of `getSystemUsers`-inferred IDs only.
- **UI:** `mergedPropertyAccess` for modal form state and unit-assignment lists (both places that enumerate `propertyAccess`).
- **API:** `mergePropertyAccessFromUserDoc()` — merge `clientAccess` + `propertyAccess` (canonical wins per client) before add/remove client access, unit-role add/remove, per-client property-access patch, and delete-user unit sync.

## Test evidence
- `bash scripts/pre-pr-checks.sh main` — passed (frontend checks on changed `UserManagement.jsx`).
- `node --check functions/backend/controllers/userManagementController.js` — passed before commit.
- **Manual:** SuperAdmin should open Edit User on a user with Client A access, confirm Client B (new tenant with no users yet) appears in **Client ID** dropdown, add unit role, save; target user’s Firestore `users/{uid}.propertyAccess` should include Client B; JWT/custom claims path unchanged.

## Residual risk / follow-up
- `clientAccess` may remain on documents as stale duplicate until a separate migration deletes it after full cutover.
- Unit-role endpoints remain SuperAdmin-only; client admins still cannot add cross-client assignments via API (unchanged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user access persistence in multiple user-management endpoints; a bug here could unintentionally overwrite or drop client/unit permissions during edits or deletes. UI change is low risk but depends on `GET /clients` availability and response shape.
> 
> **Overview**
> Fixes multi-client unit-role assignment workflows during the `clientAccess` → `propertyAccess` migration by **merging legacy and canonical access maps instead of overwriting**.
> 
> On the frontend, `UserManagement` now uses a `mergedPropertyAccess()` helper when initializing/editing user access and when enumerating unit assignments, and the SuperAdmin Edit User client dropdown is populated from existing access **plus `secureApi.getClients()`** so newly created tenants appear even if no users exist yet.
> 
> On the backend, `userManagementController` adds `mergePropertyAccessFromUserDoc()` and uses it across client-access add/remove, per-client property-access updates, unit-role add/remove, and delete-user unit sync to prevent dropping legacy `clientAccess` entries when persisting `propertyAccess`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741d9df6e6e511cf963889c9984d4e898de3cadb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->