### PR TITLE
fix(#272): owner/manager name resolution (canonical display + UID contacts)

### DIFF
--- a/frontend/sams-ui/src/api/hoaDuesAPI.js
+++ b/frontend/sams-ui/src/api/hoaDuesAPI.js
@@ -37,9 +37,7 @@ class HOADuesAPI {
    */
   async getDuesForYear(clientId, year) {
     const token = await this.getAuthToken();
-    
-    console.log(`💰 HOADuesAPI fetching dues for ${clientId} year ${year}`);
-    
+
     // Add cache-busting parameter to ensure fresh data after payments
     const cacheBuster = `_t=${Date.now()}`;
     const response = await fetch(
@@ -56,8 +54,7 @@ class HOADuesAPI {
     );
     
     const result = await handleApiResponse(response);
-    console.log(`✅ HOADuesAPI received dues data for ${Object.keys(result || {}).length} units`);
-    
+
     return result;
   }
 

--- a/frontend/sams-ui/src/api/units.js
+++ b/frontend/sams-ui/src/api/units.js
@@ -39,33 +39,24 @@ async function getAuthHeaders() {
  */
 export async function getUnits(clientId) {
   try {
-    console.log(`📋 [API] Fetching units for client: ${clientId}`);
-    
     const headers = await getAuthHeaders();
-    console.log('🔑 [API] Auth headers prepared:', { Authorization: headers.Authorization ? 'Bearer [token]' : 'missing' });
-    
+
     const response = await fetch(`${API_BASE_URL}/clients/${clientId}/units?t=${Date.now()}`, {
       method: 'GET',
       headers,
       credentials: 'include',
       cache: 'no-store',
     });
-    
-    console.log(`📡 [API] Response status: ${response.status}`);
-    
+
     const result = await response.json();
-    console.log('📋 [API] Response body:', result);
-    
+
     if (result.success) {
-      console.log(`✅ [API] Fetched ${result.count} units successfully`);
       return result;
-    } else {
-      console.error('❌ [API] Failed to fetch units:', result.error);
-      throw new Error(result.error);
     }
-    
+    console.error('Failed to fetch units:', result.error);
+    throw new Error(result.error);
   } catch (error) {
-    console.error('❌ Error fetching units:', error);
+    console.error('Error fetching units:', error);
     throw error;
   }
 }
@@ -78,8 +69,6 @@ export async function getUnits(clientId) {
  */
 export async function createUnit(clientId, unitData) {
   try {
-    console.log(`➕ Creating unit for client: ${clientId}`, unitData);
-    
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE_URL}/clients/${clientId}/units`, {
       method: 'POST',
@@ -91,15 +80,12 @@ export async function createUnit(clientId, unitData) {
     const result = await response.json();
     
     if (result.success) {
-      console.log(`✅ Created unit with ID: ${result.id}`);
       return result;
-    } else {
-      console.error('❌ Failed to create unit:', result.error);
-      throw new Error(result.error);
     }
-    
+    console.error('Failed to create unit:', result.error);
+    throw new Error(result.error);
   } catch (error) {
-    console.error('❌ Error creating unit:', error);
+    console.error('Error creating unit:', error);
     throw error;
   }
 }
@@ -113,8 +99,6 @@ export async function createUnit(clientId, unitData) {
  */
 export async function updateUnit(clientId, unitId, unitData) {
   try {
-    console.log(`✏️ Updating unit ${unitId} for client: ${clientId}`, unitData);
-    
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE_URL}/clients/${clientId}/units/${unitId}`, {
       method: 'PUT',
@@ -126,15 +110,12 @@ export async function updateUnit(clientId, unitId, unitData) {
     const result = await response.json();
     
     if (result.success) {
-      console.log(`✅ Updated unit: ${unitId}`);
       return result;
-    } else {
-      console.error('❌ Failed to update unit:', result.error);
-      throw new Error(result.error);
     }
-    
+    console.error('Failed to update unit:', result.error);
+    throw new Error(result.error);
   } catch (error) {
-    console.error('❌ Error updating unit:', error);
+    console.error('Error updating unit:', error);
     throw error;
   }
 }
@@ -147,8 +128,6 @@ export async function updateUnit(clientId, unitId, unitData) {
  */
 export async function deleteUnit(clientId, unitId) {
   try {
-    console.log(`🗑️ Deleting unit ${unitId} for client: ${clientId}`);
-    
     const headers = await getAuthHeaders();
     const response = await fetch(`${API_BASE_URL}/clients/${clientId}/units/${unitId}`, {
       method: 'DELETE',
@@ -159,15 +138,12 @@ export async function deleteUnit(clientId, unitId) {
     const result = await response.json();
     
     if (result.success) {
-      console.log(`✅ Deleted unit: ${unitId}`);
       return result;
-    } else {
-      console.error('❌ Failed to delete unit:', result.error);
-      throw new Error(result.error);
     }
-    
+    console.error('Failed to delete unit:', result.error);
+    throw new Error(result.error);
   } catch (error) {
-    console.error('❌ Error deleting unit:', error);
+    console.error('Error deleting unit:', error);
     throw error;
   }
 }

--- a/frontend/sams-ui/src/context/HOADuesContext.jsx
+++ b/frontend/sams-ui/src/context/HOADuesContext.jsx
@@ -5,8 +5,6 @@ import hoaDuesAPI from '../api/hoaDuesAPI';
 import { getFiscalYear } from '../utils/fiscalYearUtils';
 import { getMexicoDate } from '../utils/timezone';
 
-console.log('📁 [HOADuesContext] Module loaded');
-
 const HOADuesContext = createContext();
 
 // ⚠️ NO CACHING - ALL REQUESTS FETCH FRESH FROM FIRESTORE
@@ -23,31 +21,11 @@ export function HOADuesProvider({ children }) {
   const [error, setError] = useState(null);
   const [unitsWithOwners, setUnitsWithOwners] = useState([]); // Units with owner data from API
 
-  console.log('💰 [HOADuesContext] Component rendered:', {
-    hasClient: !!selectedClient,
-    clientId: selectedClient?.id,
-    selectedYear,
-    loading,
-    hasError: !!error
-  });
-
   // Set initial year when client is loaded - EXACT PATTERN from Water Bills
   useEffect(() => {
-    console.log('📅 [HOADuesContext] Year effect triggered:', {
-      hasClient: !!selectedClient,
-      clientId: selectedClient?.id,
-      currentYear: selectedYear
-    });
-    
     if (selectedClient && selectedYear === null) {
       const fiscalYearStartMonth = selectedClient.configuration?.fiscalYearStartMonth || 1;
       const currentFiscalYear = getFiscalYear(getMexicoDate(), fiscalYearStartMonth);
-      
-      console.log('📅 [HOADuesContext] Setting initial year:', {
-        client: selectedClient.id,
-        fiscalYearStartMonth,
-        calculatedYear: currentFiscalYear
-      });
       
       debug.log('HOADuesContext - Setting initial year based on client');
       debug.log('  Client:', selectedClient.id);
@@ -76,7 +54,6 @@ export function HOADuesProvider({ children }) {
       if (response.ok) {
         const unitsResponse = await response.json();
         const units = unitsResponse.data || unitsResponse;
-        console.log('👥 [HOADuesContext] Loaded units with owner data:', units.length, 'units');
         setUnitsWithOwners(units);
       } else {
         console.warn(`Failed to fetch units with owner data for client ${selectedClient.id}`);
@@ -91,17 +68,7 @@ export function HOADuesProvider({ children }) {
   // Fetch HOA dues data directly from backend
   // NO CACHING - fetches fresh from Firestore every time
   const fetchDuesData = async (year) => {
-    console.log('💰 [HOADuesContext] fetchDuesData called:', {
-      hasClient: !!selectedClient,
-      clientId: selectedClient?.id,
-      year
-    });
-    
     if (!selectedClient || !year) {
-      console.log('⚠️ [HOADuesContext] Skipping fetch - missing requirements:', {
-        hasClient: !!selectedClient,
-        year
-      });
       debug.log('HOADuesContext - Skipping fetch, missing client or year');
       return;
     }
@@ -110,7 +77,6 @@ export function HOADuesProvider({ children }) {
     // Cache-busting in hoaDuesAPI ensures we never get stale data
     
     // Fetch from API - gets all units' dues data for the year
-    console.log('🌐 [HOADuesContext] Fetching dues for year...');
     setLoading(true);
     setError(null);
     
@@ -118,28 +84,14 @@ export function HOADuesProvider({ children }) {
       debug.log('HOADuesContext - Fetching HOA dues from API for year:', year);
       const response = await hoaDuesAPI.getDuesForYear(selectedClient.id, year);
       
-      console.log('📦 [HOADuesContext] API Response received:', {
-        hasResponse: !!response,
-        unitCount: response ? Object.keys(response).length : 0,
-        units: response ? Object.keys(response) : 'none'
-      });
-      
       // The response contains all units' dues data (direct from Firestore)
       // Update state
       const dataToSet = response || {};
-      console.log('📊 [HOADuesContext] Setting dues data state:', {
-        unitCount: Object.keys(dataToSet).length,
-        units: Object.keys(dataToSet)
-      });
       setDuesData(dataToSet);
       
       debug.log('HOADuesContext - Loaded dues data for client:', selectedClient.id, 'year:', year);
     } catch (error) {
-      console.error('🚨 [HOADuesContext] Error loading dues data:', {
-        message: error.message,
-        status: error.status,
-        stack: error.stack
-      });
+      console.error('HOADuesContext: Error loading dues data:', error);
       debug.error('HOADuesContext - Error loading dues data:', error);
       // Don't set error state for 404s, just use empty data
       if (error.status !== 404) {
@@ -147,7 +99,6 @@ export function HOADuesProvider({ children }) {
       }
       setDuesData({});
     } finally {
-      console.log('🏁 [HOADuesContext] Fetch complete');
       setLoading(false);
     }
   };
@@ -163,20 +114,8 @@ export function HOADuesProvider({ children }) {
 
   // Fetch data when client or year changes
   useEffect(() => {
-    console.log('🔄 [HOADuesContext] Data fetch effect triggered:', {
-      hasClient: !!selectedClient,
-      clientId: selectedClient?.id,
-      selectedYear
-    });
-    
     if (selectedClient && selectedYear) {
-      console.log('🚀 [HOADuesContext] Conditions met - calling fetchDuesData');
       fetchDuesData(selectedYear);
-    } else {
-      console.log('⏸️ [HOADuesContext] Conditions not met - skipping fetch:', {
-        hasClient: !!selectedClient,
-        selectedYear
-      });
     }
   }, [selectedClient, selectedYear]);
 

--- a/frontend/sams-ui/src/utils/unitContactUtils.js
+++ b/frontend/sams-ui/src/utils/unitContactUtils.js
@@ -1,105 +1,84 @@
 /**
  * Unit Contact Structure Utilities (Frontend)
- * 
+ *
  * Provides normalization functions for unit owners and managers
  * Handles backward compatibility between old format (["name"]) and new format ([{name, email}])
- * 
+ *
  * Task ID: UNIT-CONTACT-CODE-UPDATE-20251216
  * Date: December 16, 2025
  */
 
-/**
- * Normalize owners array to new structure [{name, email}]
- * Assumes new format only - converts string format if found (should not happen after migration)
- * 
- * @param {Array<Object>|undefined} owners - Owners array in [{name, email}] format
- * @returns {Array<{name: string, email: string}>} Normalized owners array
- */
+import { getDisplayNameFromUser as getDisplayNameFromUserCanonical } from '../../../../shared/userIdentityDisplay.js';
+
+/** Canonical user label — same algorithm as backend `unitContactUtils` / `listUnits` resolution. */
+export function getDisplayNameFromUser(userData) {
+  return getDisplayNameFromUserCanonical(userData);
+}
+
+/** Label for a resolved unit owner/manager object from the API (name, email, optional userId). */
+export function resolvedContactLabel(contact = {}) {
+  const name = (contact.name || '').trim();
+  if (name) return name;
+  const email = (contact.email || '').trim();
+  if (email) return email;
+  return '';
+}
+
 export function normalizeOwners(owners) {
   if (!Array.isArray(owners)) return [];
-  
   return owners.map(owner => {
-    // Handle legacy string format (should be migrated, but handle gracefully)
     if (typeof owner === 'string') {
       console.warn('⚠️  Found legacy string format owner - should be migrated:', owner);
       return { name: owner.trim(), email: '' };
     }
-    // New format: {name, email}
-    return {
-      name: (owner.name || '').trim(),
-      email: (owner.email || '').trim()
-    };
-  }).filter(owner => owner.name); // Remove empty names
+    if (owner && typeof owner === 'object' && typeof owner.userId === 'string' && owner.userId.trim()) {
+      return {
+        userId: owner.userId.trim(),
+        name: (owner.name || '').trim(),
+        email: (owner.email || '').trim()
+      };
+    }
+    return { name: (owner.name || '').trim(), email: (owner.email || '').trim() };
+  }).filter(owner => owner.name || owner.userId);
 }
 
-/**
- * Normalize managers array to new structure [{name, email}]
- * Assumes new format only - converts string format if found (should not happen after migration)
- * 
- * @param {Array<Object>|undefined} managers - Managers array in [{name, email}] format
- * @returns {Array<{name: string, email: string}>} Normalized managers array
- */
 export function normalizeManagers(managers) {
   if (!Array.isArray(managers)) return [];
-  
   return managers.map(manager => {
-    // Handle legacy string format (should be migrated, but handle gracefully)
     if (typeof manager === 'string') {
       console.warn('⚠️  Found legacy string format manager - should be migrated:', manager);
       return { name: manager.trim(), email: '' };
     }
-    // New format: {name, email}
-    return {
-      name: (manager.name || '').trim(),
-      email: (manager.email || '').trim()
-    };
-  }).filter(manager => manager.name); // Remove empty names
+    if (manager && typeof manager === 'object' && typeof manager.userId === 'string' && manager.userId.trim()) {
+      return {
+        userId: manager.userId.trim(),
+        name: (manager.name || '').trim(),
+        email: (manager.email || '').trim()
+      };
+    }
+    return { name: (manager.name || '').trim(), email: (manager.email || '').trim() };
+  }).filter(manager => manager.name || manager.userId);
 }
 
-/**
- * Extract owner names as array of strings (for backward compatibility)
- * 
- * @param {Array<string|Object>|undefined} owners - Owners array (old or new format)
- * @returns {Array<string>} Array of owner names
- */
 export function getOwnerNames(owners) {
-  return normalizeOwners(owners).map(owner => owner.name);
+  return normalizeOwners(owners).map(resolvedContactLabel).filter(Boolean);
 }
 
-/**
- * Extract manager names as array of strings (for backward compatibility)
- * 
- * @param {Array<string|Object>|undefined} managers - Managers array (old or new format)
- * @returns {Array<string>} Array of manager names
- */
 export function getManagerNames(managers) {
-  return normalizeManagers(managers).map(manager => manager.name);
+  return normalizeManagers(managers).map(resolvedContactLabel).filter(Boolean);
 }
 
-/**
- * Get first owner name (for backward compatibility)
- * 
- * @param {Array<string|Object>|undefined} owners - Owners array (old or new format)
- * @returns {string} First owner name or empty string
- */
 export function getFirstOwnerName(owners) {
   const normalized = normalizeOwners(owners);
-  return normalized.length > 0 ? normalized[0].name : '';
+  return normalized.length > 0 ? resolvedContactLabel(normalized[0]) : '';
 }
 
-/**
- * Extract owner last name from first owner (for display purposes)
- * 
- * @param {Array<string|Object>|undefined} owners - Owners array (old or new format)
- * @returns {string} Last name or empty string
- */
 export function getFirstOwnerLastName(owners) {
   const normalized = normalizeOwners(owners);
-  if (normalized.length === 0 || !normalized[0].name) return '';
-  
-  const nameParts = normalized[0].name.trim().split(/\s+/);
-  if (nameParts.length > 1) {
-    return nameParts[nameParts.length - 1];
-  }
+  if (normalized.length === 0) return '';
+  const label = resolvedContactLabel(normalized[0]);
+  if (!label) return '';
+  const nameParts = label.trim().split(/\s+/);
+  if (nameParts.length > 1) return nameParts[nameParts.length - 1];
   return nameParts[0] || '';
 }

--- a/frontend/sams-ui/src/utils/unitContactUtils.js
+++ b/frontend/sams-ui/src/utils/unitContactUtils.js
@@ -30,8 +30,6 @@ export function resolvedContactLabel(contact = {}) {
   if (name) return name;
   const email = (contact.email || '').trim();
   if (email) return email;
-  const uid = getContactLinkedUserId(contact);
-  if (uid) return `User ${uid.slice(0, 8)}…`;
   return '';
 }
 

--- a/frontend/sams-ui/src/utils/unitContactUtils.js
+++ b/frontend/sams-ui/src/utils/unitContactUtils.js
@@ -15,12 +15,23 @@ export function getDisplayNameFromUser(userData) {
   return getDisplayNameFromUserCanonical(userData);
 }
 
+/** Firebase UID for a linked contact (`userId` canonical; `uid` accepted for legacy rows). */
+export function getContactLinkedUserId(contact) {
+  if (!contact || typeof contact !== 'object') return '';
+  if (typeof contact.userId === 'string' && contact.userId.trim()) return contact.userId.trim();
+  if (typeof contact.uid === 'string' && contact.uid.trim()) return contact.uid.trim();
+  return '';
+}
+
 /** Label for a resolved unit owner/manager object from the API (name, email, optional userId). */
 export function resolvedContactLabel(contact = {}) {
+  if (!contact || typeof contact !== 'object') return '';
   const name = (contact.name || '').trim();
   if (name) return name;
   const email = (contact.email || '').trim();
   if (email) return email;
+  const uid = getContactLinkedUserId(contact);
+  if (uid) return `User ${uid.slice(0, 8)}…`;
   return '';
 }
 
@@ -31,15 +42,18 @@ export function normalizeOwners(owners) {
       console.warn('⚠️  Found legacy string format owner - should be migrated:', owner);
       return { name: owner.trim(), email: '' };
     }
-    if (owner && typeof owner === 'object' && typeof owner.userId === 'string' && owner.userId.trim()) {
-      return {
-        userId: owner.userId.trim(),
-        name: (owner.name || '').trim(),
-        email: (owner.email || '').trim()
-      };
+    if (owner && typeof owner === 'object') {
+      const uid = getContactLinkedUserId(owner);
+      if (uid) {
+        return {
+          userId: uid,
+          name: (owner.name || '').trim(),
+          email: (owner.email || '').trim()
+        };
+      }
     }
     return { name: (owner.name || '').trim(), email: (owner.email || '').trim() };
-  }).filter(owner => owner.name || owner.userId);
+  }).filter(owner => owner.name || getContactLinkedUserId(owner));
 }
 
 export function normalizeManagers(managers) {
@@ -49,15 +63,18 @@ export function normalizeManagers(managers) {
       console.warn('⚠️  Found legacy string format manager - should be migrated:', manager);
       return { name: manager.trim(), email: '' };
     }
-    if (manager && typeof manager === 'object' && typeof manager.userId === 'string' && manager.userId.trim()) {
-      return {
-        userId: manager.userId.trim(),
-        name: (manager.name || '').trim(),
-        email: (manager.email || '').trim()
-      };
+    if (manager && typeof manager === 'object') {
+      const uid = getContactLinkedUserId(manager);
+      if (uid) {
+        return {
+          userId: uid,
+          name: (manager.name || '').trim(),
+          email: (manager.email || '').trim()
+        };
+      }
     }
     return { name: (manager.name || '').trim(), email: (manager.email || '').trim() };
-  }).filter(manager => manager.name || manager.userId);
+  }).filter(manager => manager.name || getContactLinkedUserId(manager));
 }
 
 export function getOwnerNames(owners) {

--- a/frontend/sams-ui/src/utils/unitUtils.js
+++ b/frontend/sams-ui/src/utils/unitUtils.js
@@ -2,6 +2,8 @@
  * Utility functions for working with unit data
  */
 
+import { normalizeOwners, resolvedContactLabel } from './unitContactUtils.js';
+
 /**
  * Formats a unit ID with the owner's last name in parentheses
  * 
@@ -12,40 +14,7 @@ export function formatUnitIdWithOwner(unit) {
   if (!unit) return '';
   
   const unitId = unit.unitId || '';
-  
-  // Check for owner information in different possible properties
-  let ownerName = '';
-  
-  // First try the owners array (primary data structure) - handle both old format ["name"] and new format [{name, email}]
-  if (Array.isArray(unit.owners) && unit.owners.length > 0) {
-    const firstOwner = unit.owners[0];
-    if (typeof firstOwner === 'string') {
-      ownerName = firstOwner;
-    } else if (firstOwner && typeof firstOwner === 'object') {
-      ownerName = (firstOwner.name || firstOwner.email || '').trim();
-    }
-  } 
-  // Fall back to owner property if owners array isn't available
-  else if (unit.owner) {
-    ownerName = typeof unit.owner === 'string'
-      ? unit.owner
-      : (unit.owner.name || unit.owner.email || '').trim();
-  }
-  
-  // Extract last name from the owner's full name
-  let lastName = '';
-  
-  if (ownerName) {
-    // First try to match a name with spaces (e.g., "First Last")
-    const lastNameMatch = ownerName.match(/\s(\S+)$/);
-    if (lastNameMatch) {
-      lastName = lastNameMatch[1];
-    } else {
-      // If no space found, use the whole name
-      lastName = ownerName;
-    }
-  }
-  
+  const { lastName } = getOwnerInfo(unit);
   return `${unitId} (${lastName})`;
 }
 
@@ -59,44 +28,37 @@ export function getOwnerInfo(unit) {
   if (!unit) return { unitId: '', firstName: '', lastName: '', email: '' };
   
   const unitId = unit.unitId || '';
-  
-  // Check for owner information in different possible properties
-  let ownerName = '';
+
   let email = '';
-  
-  // First try the owners array (handle both old format ["name"] and new format [{name, email}])
-  if (Array.isArray(unit.owners) && unit.owners.length > 0) {
-    const firstOwner = unit.owners[0];
-    if (typeof firstOwner === 'string') {
-      ownerName = firstOwner;
-    } else if (firstOwner && typeof firstOwner === 'object') {
-      ownerName = (firstOwner.name || firstOwner.email || '').trim();
-      email = (firstOwner.email || '').trim();
-    }
-  } 
-  // Fall back to owner property if owners array isn't available
-  else if (unit.owner) {
-    ownerName = typeof unit.owner === 'string'
-      ? unit.owner
-      : (unit.owner.name || unit.owner.email || '').trim();
+
+  const normalized = normalizeOwners(
+    Array.isArray(unit.owners) && unit.owners.length > 0
+      ? unit.owners
+      : unit.owner
+        ? [typeof unit.owner === 'string' ? unit.owner : unit.owner]
+        : []
+  );
+
+  const primary = normalized[0];
+  if (primary && typeof primary === 'object') {
+    email = (primary.email || '').trim();
   }
-  
-  // Extract first and last name (handle case where ownerName might be empty or not a string)
-  if (!ownerName || typeof ownerName !== 'string') {
-    ownerName = '';
-  }
-  const nameParts = ownerName.trim().split(/\s+/);
+
+  const ownerLabel = primary ? resolvedContactLabel(primary) : '';
+
+  const nameParts = ownerLabel.trim().split(/\s+/).filter(Boolean);
   let firstName = '';
   let lastName = '';
-  
+
   if (nameParts.length >= 1) {
     firstName = nameParts[0];
-    // Last name is the last part of the name
     if (nameParts.length > 1) {
       lastName = nameParts[nameParts.length - 1];
+    } else {
+      lastName = nameParts[0];
     }
   }
-  
+
   return {
     unitId,
     firstName,

--- a/frontend/sams-ui/src/utils/unitUtils.js
+++ b/frontend/sams-ui/src/utils/unitUtils.js
@@ -22,12 +22,14 @@ export function formatUnitIdWithOwner(unit) {
     if (typeof firstOwner === 'string') {
       ownerName = firstOwner;
     } else if (firstOwner && typeof firstOwner === 'object') {
-      ownerName = firstOwner.name || '';
+      ownerName = (firstOwner.name || firstOwner.email || '').trim();
     }
   } 
   // Fall back to owner property if owners array isn't available
   else if (unit.owner) {
-    ownerName = typeof unit.owner === 'string' ? unit.owner : (unit.owner.name || '');
+    ownerName = typeof unit.owner === 'string'
+      ? unit.owner
+      : (unit.owner.name || unit.owner.email || '').trim();
   }
   
   // Extract last name from the owner's full name
@@ -68,13 +70,15 @@ export function getOwnerInfo(unit) {
     if (typeof firstOwner === 'string') {
       ownerName = firstOwner;
     } else if (firstOwner && typeof firstOwner === 'object') {
-      ownerName = firstOwner.name || '';
-      email = firstOwner.email || '';
+      ownerName = (firstOwner.name || firstOwner.email || '').trim();
+      email = (firstOwner.email || '').trim();
     }
   } 
   // Fall back to owner property if owners array isn't available
   else if (unit.owner) {
-    ownerName = typeof unit.owner === 'string' ? unit.owner : (unit.owner.name || '');
+    ownerName = typeof unit.owner === 'string'
+      ? unit.owner
+      : (unit.owner.name || unit.owner.email || '').trim();
   }
   
   // Extract first and last name (handle case where ownerName might be empty or not a string)

--- a/frontend/sams-ui/src/views/HOADuesView.jsx
+++ b/frontend/sams-ui/src/views/HOADuesView.jsx
@@ -32,20 +32,16 @@ import PaymentDetailsModal from '../components/PaymentDetailsModal';
 import './HOADuesView.css';
 
 function HOADuesView() {
-  console.log('🔴 HOADuesView component rendering');
-  
   const { 
     units, 
     unitsWithOwners,
-    duesData, 
+    duesData,
     loading, 
     error, 
     selectedYear, 
     setSelectedYear,
     refreshData
   } = useHOADues();
-  
-  console.log('🔴 HOADuesView - selectedYear from context:', selectedYear);
   
   // Get the client name from ClientContext
   const { selectedClient } = useClient();
@@ -58,12 +54,6 @@ function HOADuesView() {
   
   // Get dues frequency configuration (monthly or quarterly)
   const duesFrequency = selectedClient?.feeStructure?.duesFrequency || 'monthly';
-  
-  // DEBUG: Log client configuration
-  console.log('HOA Dues View - Selected Client:', selectedClient);
-  console.log('HOA Dues View - Fiscal Year Start Month:', fiscalYearStartMonth);
-  console.log('HOA Dues View - Dues Frequency:', duesFrequency);
-  console.log('HOA Dues View - Selected Year:', selectedYear);
   
   // Note: selectedUnitId and selectedMonth kept for context menu navigation
   const [selectedUnitId, setSelectedUnitId] = useState(null);
@@ -161,7 +151,7 @@ function HOADuesView() {
       // Not paid - only admin can open payment modal; non-admin view-only (navigate without opening)
       const canRecordPayment = isSuperAdmin(samsUser) || isAdmin(samsUser, selectedClient?.id);
       if (canRecordPayment) {
-        console.log(`💳 Opening unified payment modal for unit ${unitId}, month ${fiscalMonth}`);
+        debug.log(`Opening unified payment for unit ${unitId}, month ${fiscalMonth}`);
         navigate('/transactions', { 
           state: { 
             openUnifiedPayment: true, 

--- a/frontend/sams-ui/src/views/HOADuesView.jsx
+++ b/frontend/sams-ui/src/views/HOADuesView.jsx
@@ -13,7 +13,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { getOwnerInfo } from '../utils/unitUtils';
 import { isSuperAdmin, isAdmin } from '../utils/userRoles';
-import { getFirstOwnerName, normalizeOwners, normalizeManagers } from '../utils/unitContactUtils.js';
+import { getFirstOwnerName, normalizeOwners, normalizeManagers, resolvedContactLabel } from '../utils/unitContactUtils.js';
 import {
   getFiscalMonthNames,
   getCurrentFiscalMonth,
@@ -375,10 +375,10 @@ function HOADuesView() {
     const managers = normalizeManagers(unitWithOwner.managers);
     const lines = [];
     if (owners.length > 0) {
-      lines.push(`Owner${owners.length > 1 ? 's' : ''}: ${owners.map(o => o.name).join(', ')}`);
+      lines.push(`Owner${owners.length > 1 ? 's' : ''}: ${owners.map(resolvedContactLabel).filter(Boolean).join(', ')}`);
     }
     if (managers.length > 0) {
-      lines.push(`Manager${managers.length > 1 ? 's' : ''}: ${managers.map(m => m.name).join(', ')}`);
+      lines.push(`Manager${managers.length > 1 ? 's' : ''}: ${managers.map(resolvedContactLabel).filter(Boolean).join(', ')}`);
     }
     return lines.join('\n') || 'No contact info';
   };

--- a/frontend/sams-ui/src/views/ListManagementView.jsx
+++ b/frontend/sams-ui/src/views/ListManagementView.jsx
@@ -31,7 +31,13 @@ import { useStatusBar } from '../context/StatusBarContext';
 import { useAuth } from '../context/AuthContext';
 import { useSecureApi } from '../api/secureApiClient';
 import { isSuperAdmin, isAdmin } from '../utils/userRoles';
-import { normalizeOwners, normalizeManagers, resolvedContactLabel } from '../utils/unitContactUtils';
+import {
+  normalizeOwners,
+  normalizeManagers,
+  resolvedContactLabel,
+  getOwnerNames,
+  getManagerNames
+} from '../utils/unitContactUtils';
 import { createVendor, updateVendor, deleteVendor } from '../api/vendors';
 import { createCategory, updateCategory, deleteCategory } from '../api/categories';
 import { createPaymentMethod, updatePaymentMethod, deletePaymentMethod } from '../api/paymentMethods';
@@ -889,13 +895,8 @@ function ListManagementView() {
       const units = response.data || [];
       const headers = ['Unit ID', 'Unit Name', 'Owners', 'Managers', 'Status', 'Property Type', 'Square Feet', 'Notes'];
       const rows = units.map(u => {
-        // Format owners
-        const owners = u.owners || [];
-        const ownerNames = owners.map(o => o.name || '').filter(Boolean).join('; ');
-        
-        // Format managers
-        const managers = u.managers || [];
-        const managerNames = managers.map(m => m.name || '').filter(Boolean).join('; ');
+        const ownerNames = getOwnerNames(u.owners || []).join('; ');
+        const managerNames = getManagerNames(u.managers || []).join('; ');
         
         return [
           u.unitId || '',

--- a/frontend/sams-ui/src/views/ListManagementView.jsx
+++ b/frontend/sams-ui/src/views/ListManagementView.jsx
@@ -31,7 +31,7 @@ import { useStatusBar } from '../context/StatusBarContext';
 import { useAuth } from '../context/AuthContext';
 import { useSecureApi } from '../api/secureApiClient';
 import { isSuperAdmin, isAdmin } from '../utils/userRoles';
-import { normalizeOwners, normalizeManagers } from '../utils/unitContactUtils';
+import { normalizeOwners, normalizeManagers, resolvedContactLabel } from '../utils/unitContactUtils';
 import { createVendor, updateVendor, deleteVendor } from '../api/vendors';
 import { createCategory, updateCategory, deleteCategory } from '../api/categories';
 import { createPaymentMethod, updatePaymentMethod, deletePaymentMethod } from '../api/paymentMethods';
@@ -426,11 +426,14 @@ function ListManagementView() {
             render: (value, item) => {
               const owners = normalizeOwners(item.owners || []);
               if (owners.length === 0) return 'Not specified';
-              return owners.map(owner => {
-                const parts = [owner.name];
-                if (owner.email) parts.push(`(${owner.email})`);
+              const ownerLines = owners.map(owner => {
+                const label = resolvedContactLabel(owner);
+                if (!label) return '';
+                const parts = [label];
+                if (owner.email && label !== owner.email.trim()) parts.push(`(${owner.email})`);
                 return parts.join(' ');
-              }).join(', ');
+              }).filter(Boolean);
+              return ownerLines.length > 0 ? ownerLines.join(', ') : 'Not specified';
             }
           },
           { 
@@ -439,11 +442,14 @@ function ListManagementView() {
             render: (value, item) => {
               const managers = normalizeManagers(item.managers || []);
               if (managers.length === 0) return 'None assigned';
-              return managers.map(manager => {
-                const parts = [manager.name];
-                if (manager.email) parts.push(`(${manager.email})`);
+              const mgrLines = managers.map(manager => {
+                const label = resolvedContactLabel(manager);
+                if (!label) return '';
+                const parts = [label];
+                if (manager.email && label !== manager.email.trim()) parts.push(`(${manager.email})`);
                 return parts.join(' ');
-              }).join(', ');
+              }).filter(Boolean);
+              return mgrLines.length > 0 ? mgrLines.join(', ') : 'None assigned';
             }
           },
           { key: 'status', label: 'Status' },

--- a/functions/backend/controllers/unitsController.js
+++ b/functions/backend/controllers/unitsController.js
@@ -4,11 +4,10 @@ import { writeAuditLog } from '../utils/auditLogger.js';
 import { getNow } from '../services/DateService.js';
 import {
   normalizeContactsForStorage,
-  resolveOwners,
-  resolveManagers,
+  resolveUnitContactsForApi,
   getContactLinkedUserId,
-  buildFirebaseAuthCache,
-  needsAuthEnrichment,
+  summarizeUsersCollectionCoverage,
+  perUnitContactSnapshot,
 } from '../utils/unitContactUtils.js';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
 
@@ -158,8 +157,11 @@ async function deleteUnit(clientId, unitId) {
   }
 }
 
-// List all units under a client
-async function listUnits(clientId) {
+/**
+ * Load all units, batch-read `users/{uid}` for linked contacts, return resolved API rows + map for diagnostics.
+ * @returns {Promise<{ resolvedUnits: Array, userMap: Map<string, object|null>, allUserIds: string[] }|null>}
+ */
+async function loadResolvedUnitsBundle(clientId) {
   try {
     const db = await getDb();
     const snapshot = await db.collection(`clients/${clientId}/units`).get();
@@ -173,7 +175,7 @@ async function listUnits(clientId) {
         logDebug(`⚠️ Skipping ${doc.id} document from units list`);
         return;
       }
-      
+
       const data = doc.data();
       const ownersRaw = Array.isArray(data.owners) ? data.owners : (data.owner ? [data.owner] : []);
       const managersRaw = Array.isArray(data.managers) ? data.managers : [];
@@ -185,7 +187,7 @@ async function listUnits(clientId) {
         const id = getContactLinkedUserId(manager);
         if (id) allUserIds.add(id);
       });
-      
+
       units.push({
         unitId: doc.id, // Document ID is the unit identifier
         ...data,
@@ -210,24 +212,66 @@ async function listUnits(clientId) {
       });
     }
 
-    const authNeeded = userIds.filter((uid) => needsAuthEnrichment(userMap.get(uid) || null));
-    const sharedAuthCache = await buildFirebaseAuthCache(authNeeded);
-
     const resolvedUnits = [];
     for (const unit of units) {
       const { ownersRaw, managersRaw, ...unitWithoutRaw } = unit;
+      const { owners, managers } = await resolveUnitContactsForApi(
+        ownersRaw,
+        managersRaw,
+        db,
+        userMap
+      );
       resolvedUnits.push({
         ...unitWithoutRaw,
-        owners: await resolveOwners(ownersRaw, db, userMap, sharedAuthCache),
-        managers: await resolveManagers(managersRaw, db, userMap, sharedAuthCache),
+        owners,
+        managers
       });
     }
 
-    return resolvedUnits;
+    return { resolvedUnits, userMap, allUserIds: userIds };
   } catch (error) {
     logError('❌ Error listing units:', error);
-    return [];
+    return null;
   }
+}
+
+// List all units under a client
+async function listUnits(clientId) {
+  const bundle = await loadResolvedUnitsBundle(clientId);
+  return bundle ? bundle.resolvedUnits : [];
+}
+
+/** Same data as listUnits plus Firestore coverage stats (for ?contactDiagnostics=1). */
+async function listUnitsWithContactDiagnostics(clientId) {
+  const bundle = await loadResolvedUnitsBundle(clientId);
+  if (!bundle) {
+    return {
+      units: [],
+      contactDiagnostics: {
+        clientId,
+        error: 'load_failed',
+        totalUniqueUserIds: 0,
+        missingUserDocIds: [],
+        missingUserDocCount: 0,
+        emptyProfileUserIds: [],
+        emptyProfileCount: 0,
+        perUnit: [],
+      },
+    };
+  }
+  const coverage = summarizeUsersCollectionCoverage(bundle.allUserIds, bundle.userMap);
+  const contactDiagnostics = {
+    clientId,
+    ...coverage,
+    perUnit: perUnitContactSnapshot(bundle.resolvedUnits),
+  };
+  logInfo('📊 units contactDiagnostics', {
+    clientId,
+    unitCount: bundle.resolvedUnits.length,
+    missingUserDocCount: coverage.missingUserDocCount,
+    emptyProfileCount: coverage.emptyProfileCount,
+  });
+  return { units: bundle.resolvedUnits, contactDiagnostics };
 }
 
 // Update unit managers
@@ -272,6 +316,7 @@ export {
   updateUnit,
   deleteUnit,
   listUnits,
+  listUnitsWithContactDiagnostics,
   updateUnitManagers,
   addUnitEmail,
 };

--- a/functions/backend/controllers/unitsController.js
+++ b/functions/backend/controllers/unitsController.js
@@ -7,6 +7,8 @@ import {
   resolveOwners,
   resolveManagers,
   getContactLinkedUserId,
+  buildFirebaseAuthCache,
+  needsAuthEnrichment,
 } from '../utils/unitContactUtils.js';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
 
@@ -208,13 +210,16 @@ async function listUnits(clientId) {
       });
     }
 
+    const authNeeded = userIds.filter((uid) => needsAuthEnrichment(userMap.get(uid) || null));
+    const sharedAuthCache = await buildFirebaseAuthCache(authNeeded);
+
     const resolvedUnits = [];
     for (const unit of units) {
       const { ownersRaw, managersRaw, ...unitWithoutRaw } = unit;
       resolvedUnits.push({
         ...unitWithoutRaw,
-        owners: await resolveOwners(ownersRaw, db, userMap),
-        managers: await resolveManagers(managersRaw, db, userMap),
+        owners: await resolveOwners(ownersRaw, db, userMap, sharedAuthCache),
+        managers: await resolveManagers(managersRaw, db, userMap, sharedAuthCache),
       });
     }
 

--- a/functions/backend/controllers/unitsController.js
+++ b/functions/backend/controllers/unitsController.js
@@ -6,6 +6,7 @@ import {
   normalizeContactsForStorage,
   resolveOwners,
   resolveManagers,
+  getContactLinkedUserId,
 } from '../utils/unitContactUtils.js';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
 
@@ -175,16 +176,12 @@ async function listUnits(clientId) {
       const ownersRaw = Array.isArray(data.owners) ? data.owners : (data.owner ? [data.owner] : []);
       const managersRaw = Array.isArray(data.managers) ? data.managers : [];
       ownersRaw.forEach(owner => {
-        if (owner && typeof owner === 'object' && typeof owner.userId === 'string') {
-          const userId = owner.userId.trim();
-          if (userId) allUserIds.add(userId);
-        }
+        const id = getContactLinkedUserId(owner);
+        if (id) allUserIds.add(id);
       });
       managersRaw.forEach(manager => {
-        if (manager && typeof manager === 'object' && typeof manager.userId === 'string') {
-          const userId = manager.userId.trim();
-          if (userId) allUserIds.add(userId);
-        }
+        const id = getContactLinkedUserId(manager);
+        if (id) allUserIds.add(id);
       });
       
       units.push({

--- a/functions/backend/routes/units.js
+++ b/functions/backend/routes/units.js
@@ -1,7 +1,15 @@
 // backend/routes/units.js
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
 import express from 'express';
-import { createUnit, updateUnit, deleteUnit, listUnits, updateUnitManagers, addUnitEmail } from '../controllers/unitsController.js';
+import {
+  createUnit,
+  updateUnit,
+  deleteUnit,
+  listUnits,
+  listUnitsWithContactDiagnostics,
+  updateUnitManagers,
+  addUnitEmail,
+} from '../controllers/unitsController.js';
 import { authenticateUserWithProfile } from '../middleware/clientAuth.js';
 import { getDb } from '../firebase.js';
 
@@ -20,8 +28,22 @@ router.get('/', authenticateUserWithProfile, async (req, res) => {
     }
 
     logDebug(`📋 Fetching units for client: ${clientId}`);
+    const diagnostics =
+      req.query.contactDiagnostics === '1' ||
+      req.query.contactDiagnostics === 'true';
+
+    if (diagnostics) {
+      const { units, contactDiagnostics } = await listUnitsWithContactDiagnostics(clientId);
+      return res.json({
+        success: true,
+        data: units,
+        count: units.length,
+        contactDiagnostics,
+      });
+    }
+
     const units = await listUnits(clientId);
-    
+
     res.json({
       success: true,
       data: units,

--- a/functions/backend/utils/unitContactUtils.js
+++ b/functions/backend/utils/unitContactUtils.js
@@ -9,17 +9,11 @@
  */
 
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
+import { getDisplayNameFromUser as getDisplayNameFromUserShared } from '../../../shared/userIdentityDisplay.js';
 
-/** Exported for reuse (e.g. WhatsApp webhook phone → user display name). */
-export function getDisplayNameFromUser(userData = {}) {
-  const profile = userData.profile || {};
-  const firstName = typeof profile.firstName === 'string' ? profile.firstName.trim() : '';
-  const lastName = typeof profile.lastName === 'string' ? profile.lastName.trim() : '';
-  const fullName = `${firstName} ${lastName}`.trim();
-
-  if (fullName) return fullName;
-  if (typeof userData.name === 'string') return userData.name.trim();
-  return '';
+/** Re-export canonical identity label (shared with frontend). */
+export function getDisplayNameFromUser(userData) {
+  return getDisplayNameFromUserShared(userData);
 }
 
 /** Exported for reuse (e.g. WhatsApp webhook phone matching). */

--- a/functions/backend/utils/unitContactUtils.js
+++ b/functions/backend/utils/unitContactUtils.js
@@ -26,13 +26,20 @@ function getEmailFromUser(userData = {}) {
   return typeof userData.email === 'string' ? userData.email.trim() : '';
 }
 
+/** Firebase UID for a linked contact (`userId` canonical; `uid` accepted for legacy rows). */
+export function getContactLinkedUserId(contact) {
+  if (!contact || typeof contact !== 'object') return '';
+  if (typeof contact.userId === 'string' && contact.userId.trim()) return contact.userId.trim();
+  if (typeof contact.uid === 'string' && contact.uid.trim()) return contact.uid.trim();
+  return '';
+}
+
 function getUniqueUserIds(contacts) {
   if (!Array.isArray(contacts)) return [];
 
   return [...new Set(
     contacts
-      .filter(contact => contact && typeof contact === 'object' && typeof contact.userId === 'string')
-      .map(contact => contact.userId.trim())
+      .map(contact => getContactLinkedUserId(contact))
       .filter(Boolean)
   )];
 }
@@ -65,8 +72,9 @@ function resolveContactWithCache(contact, userCache) {
     return contact;
   }
 
-  if (typeof contact.userId === 'string' && contact.userId.trim()) {
-    const userId = contact.userId.trim();
+  const linkedId = getContactLinkedUserId(contact);
+  if (linkedId) {
+    const userId = linkedId;
     const userData = userCache.get(userId);
 
     if (!userData) {
@@ -104,8 +112,9 @@ export function normalizeContactForStorage(entry) {
     return null;
   }
 
-  if (typeof entry.userId === 'string' && entry.userId.trim()) {
-    return { userId: entry.userId.trim() };
+  const linked = getContactLinkedUserId(entry);
+  if (linked) {
+    return { userId: linked };
   }
 
   const name = typeof entry.name === 'string' ? entry.name.trim() : '';
@@ -144,10 +153,10 @@ export function normalizeOwners(owners) {
       logWarn('⚠️  Found legacy string format owner - should be migrated:', owner);
       return { name: owner.trim(), email: '' };
     }
-    // UID format: {userId}
-    if (typeof owner.userId === 'string' && owner.userId.trim()) {
+    const linked = getContactLinkedUserId(owner);
+    if (linked) {
       return {
-        userId: owner.userId.trim(),
+        userId: linked,
         name: (owner.name || '').trim(),
         email: (owner.email || '').trim(),
         phone: (owner.phone || '').trim()
@@ -158,7 +167,7 @@ export function normalizeOwners(owners) {
       name: (owner.name || '').trim(),
       email: (owner.email || '').trim()
     };
-  }).filter(owner => owner.name || owner.userId); // Keep UID entries even without names
+  }).filter(owner => owner.name || getContactLinkedUserId(owner)); // Keep UID entries even without names
 }
 
 /**
@@ -177,10 +186,10 @@ export function normalizeManagers(managers) {
       logWarn('⚠️  Found legacy string format manager - should be migrated:', manager);
       return { name: manager.trim(), email: '' };
     }
-    // UID format: {userId}
-    if (typeof manager.userId === 'string' && manager.userId.trim()) {
+    const linked = getContactLinkedUserId(manager);
+    if (linked) {
       return {
-        userId: manager.userId.trim(),
+        userId: linked,
         name: (manager.name || '').trim(),
         email: (manager.email || '').trim(),
         phone: (manager.phone || '').trim()
@@ -191,7 +200,7 @@ export function normalizeManagers(managers) {
       name: (manager.name || '').trim(),
       email: (manager.email || '').trim()
     };
-  }).filter(manager => manager.name || manager.userId); // Keep UID entries even without names
+  }).filter(manager => manager.name || getContactLinkedUserId(manager)); // Keep UID entries even without names
 }
 
 /**

--- a/functions/backend/utils/unitContactUtils.js
+++ b/functions/backend/utils/unitContactUtils.js
@@ -1,16 +1,22 @@
 /**
  * Unit Contact Structure Utilities
- * 
- * Provides normalization functions for unit owners and managers
- * Handles backward compatibility between old format (["name"]) and new format ([{name, email}])
- * 
+ *
+ * Canonical display path for unit owners/managers:
+ * - Raw unit arrays store `{ userId }` (NRM) and/or legacy `{ name, email }`.
+ * - Resolution loads Firestore `users/{userId}` only; profile strings come from
+ *   `shared/userIdentityDisplay.js` (same rules as frontend).
+ * - Firebase Auth is for login only — not used here.
+ *
  * Task ID: UNIT-CONTACT-CODE-UPDATE-20251216
  * Date: December 16, 2025
  */
 
-import admin from 'firebase-admin';
-import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
-import { getDisplayNameFromUser as getDisplayNameFromUserShared } from '../../../shared/userIdentityDisplay.js';
+import { logWarn } from '../../shared/logger.js';
+import {
+  getDisplayNameFromUser as getDisplayNameFromUserShared,
+  getCanonicalEmailFromUser,
+  getCanonicalPhoneFromUser,
+} from '../../../shared/userIdentityDisplay.js';
 
 /** Re-export canonical identity label (shared with frontend). */
 export function getDisplayNameFromUser(userData) {
@@ -19,12 +25,7 @@ export function getDisplayNameFromUser(userData) {
 
 /** Exported for reuse (e.g. WhatsApp webhook phone matching). */
 export function getPhoneFromUser(userData = {}) {
-  const profile = userData.profile || {};
-  return typeof profile.phone === 'string' ? profile.phone.trim() : '';
-}
-
-function getEmailFromUser(userData = {}) {
-  return typeof userData.email === 'string' ? userData.email.trim() : '';
+  return getCanonicalPhoneFromUser(userData);
 }
 
 /** Firebase UID for a linked contact (`userId` canonical; `uid` accepted for legacy rows). */
@@ -63,45 +64,7 @@ async function buildUserCache(userIds, db, existingCache = new Map()) {
   return existingCache;
 }
 
-/**
- * Only fetch Firebase Auth when there is no Firestore `users/{uid}` document.
- * Many SAMS accounts exist only in Firestore (contact-only / no Auth user); calling getUser for those
- * UIDs fails with user-not-found and does not improve labels. Display names must come from Firestore
- * via getDisplayNameFromUser when a doc exists.
- */
-export function needsAuthEnrichment(userData) {
-  return !userData;
-}
-
-/** Batch Firebase Auth lookups for UIDs (dedupe before calling). */
-export async function buildFirebaseAuthCache(userIds) {
-  const map = new Map();
-  if (!Array.isArray(userIds) || userIds.length === 0) return map;
-
-  await Promise.all(
-    userIds.map(async (uid) => {
-      try {
-        const rec = await admin.auth().getUser(uid);
-        map.set(uid, {
-          displayName: (rec.displayName || '').trim(),
-          email: (rec.email || '').trim(),
-          phoneNumber: (rec.phoneNumber || '').trim()
-        });
-      } catch (e) {
-        const code = e?.code || e?.errorInfo?.code || '';
-        if (code === 'auth/user-not-found') {
-          logDebug(`Firebase Auth: no user for ${uid} (expected when uid has no Auth record)`);
-        } else {
-          logWarn(`Firebase Auth getUser failed for ${uid}: ${e.message}`);
-        }
-        map.set(uid, null);
-      }
-    })
-  );
-  return map;
-}
-
-function resolveContactWithCache(contact, userCache, authCache = null) {
+function resolveContactWithCache(contact, userCache) {
   // Normalize legacy string format to {name, email, phone} for consistent API response
   if (typeof contact === 'string') {
     const name = contact.trim();
@@ -116,16 +79,9 @@ function resolveContactWithCache(contact, userCache, authCache = null) {
     const userId = linkedId;
     const userData = userCache.get(userId);
 
-    let name = userData ? getDisplayNameFromUser(userData) : '';
-    let email = userData ? getEmailFromUser(userData) : '';
-    let phone = userData ? getPhoneFromUser(userData) : '';
-
-    const auth = authCache?.get(userId);
-    if (auth) {
-      if (!name && auth.displayName) name = auth.displayName;
-      if (!email && auth.email) email = auth.email;
-      if (!phone && auth.phoneNumber) phone = auth.phoneNumber;
-    }
+    const name = userData ? getDisplayNameFromUser(userData) : '';
+    const email = userData ? getCanonicalEmailFromUser(userData) : '';
+    const phone = userData ? getCanonicalPhoneFromUser(userData) : '';
 
     const displayName = name || email || '';
     return {
@@ -265,14 +221,33 @@ export async function buildUserCacheForUnits(units, db) {
 }
 
 /**
+ * Canonical API helper: resolve both owners and managers from Firestore `users` in one call.
+ * Use from listUnits / single-unit endpoints so behavior does not drift.
+ *
+ * @param {Array|undefined} owners
+ * @param {Array|undefined} managers
+ * @param {FirebaseFirestore.Firestore} db
+ * @param {Map<string, object|null>|null} existingUserCache - optional preloaded `users/{uid}` map (e.g. listUnits batch)
+ * @returns {Promise<{ owners: Array<Object>, managers: Array<Object> }>}
+ */
+export async function resolveUnitContactsForApi(owners, managers, db, existingUserCache = null) {
+  const [resolvedOwners, resolvedManagers] = await Promise.all([
+    resolveOwners(owners, db, existingUserCache),
+    resolveManagers(managers, db, existingUserCache)
+  ]);
+  return { owners: resolvedOwners, managers: resolvedManagers };
+}
+
+/**
  * Resolve owners to enriched owner objects for API responses.
  * Supports mixed arrays of {userId} and legacy {name, email}.
  *
  * @param {Array<Object>|undefined} owners
  * @param {FirebaseFirestore.Firestore} db
+ * @param {Map<string, object|null>|null} existingCache - optional preloaded users map
  * @returns {Promise<Array<Object>>}
  */
-export async function resolveOwners(owners, db, existingCache = null, prebuiltAuthCache = null) {
+export async function resolveOwners(owners, db, existingCache = null) {
   if (!Array.isArray(owners) || owners.length === 0) {
     return [];
   }
@@ -285,13 +260,7 @@ export async function resolveOwners(owners, db, existingCache = null, prebuiltAu
   const userIds = getUniqueUserIds(owners);
   const userCache = await buildUserCache(userIds, db, existingCache || new Map());
 
-  const authCache =
-    prebuiltAuthCache ||
-    (await buildFirebaseAuthCache(
-      userIds.filter((uid) => needsAuthEnrichment(userCache.get(uid) || null))
-    ));
-
-  return owners.map(owner => resolveContactWithCache(owner, userCache, authCache)).filter(Boolean);
+  return owners.map(owner => resolveContactWithCache(owner, userCache)).filter(Boolean);
 }
 
 /**
@@ -300,9 +269,10 @@ export async function resolveOwners(owners, db, existingCache = null, prebuiltAu
  *
  * @param {Array<Object>|undefined} managers
  * @param {FirebaseFirestore.Firestore} db
+ * @param {Map<string, object|null>|null} existingCache - optional preloaded users map
  * @returns {Promise<Array<Object>>}
  */
-export async function resolveManagers(managers, db, existingCache = null, prebuiltAuthCache = null) {
+export async function resolveManagers(managers, db, existingCache = null) {
   if (!Array.isArray(managers) || managers.length === 0) {
     return [];
   }
@@ -315,13 +285,7 @@ export async function resolveManagers(managers, db, existingCache = null, prebui
   const userIds = getUniqueUserIds(managers);
   const userCache = await buildUserCache(userIds, db, existingCache || new Map());
 
-  const authCache =
-    prebuiltAuthCache ||
-    (await buildFirebaseAuthCache(
-      userIds.filter((uid) => needsAuthEnrichment(userCache.get(uid) || null))
-    ));
-
-  return managers.map(manager => resolveContactWithCache(manager, userCache, authCache)).filter(Boolean);
+  return managers.map(manager => resolveContactWithCache(manager, userCache)).filter(Boolean);
 }
 
 /**
@@ -403,4 +367,71 @@ export function joinOwnerNames(owners, separator = ', ') {
  */
 export function joinManagerNames(managers, separator = ', ') {
   return getManagerNames(managers).join(separator);
+}
+
+function profileHasDisplayableData(userData) {
+  if (!userData || typeof userData !== 'object') return false;
+  return Boolean(
+    getDisplayNameFromUser(userData).trim() ||
+      getCanonicalEmailFromUser(userData).trim() ||
+      getCanonicalPhoneFromUser(userData).trim()
+  );
+}
+
+/**
+ * Compare requested UIDs (from unit owner/manager links) to Firestore `users/{uid}` docs.
+ * Use with GET /clients/:id/units?contactDiagnostics=1 to see why names are blank.
+ *
+ * @param {string[]} userIds
+ * @param {Map<string, object|null>} userMap - from batched users collection reads
+ */
+export function summarizeUsersCollectionCoverage(userIds, userMap) {
+  const missingUserDocIds = [];
+  const emptyProfileUserIds = [];
+  for (const uid of userIds) {
+    const data = userMap.get(uid);
+    if (data == null) {
+      missingUserDocIds.push(uid);
+      continue;
+    }
+    if (!profileHasDisplayableData(data)) {
+      emptyProfileUserIds.push(uid);
+    }
+  }
+  return {
+    totalUniqueUserIds: userIds.length,
+    missingUserDocIds,
+    missingUserDocCount: missingUserDocIds.length,
+    emptyProfileUserIds,
+    emptyProfileCount: emptyProfileUserIds.length,
+  };
+}
+
+/**
+ * Per-unit snapshot of resolved owner/manager rows (what the API returns after Firestore merge).
+ *
+ * @param {Array<{ unitId: string, owners?: Array, managers?: Array }>} resolvedUnits
+ */
+export function perUnitContactSnapshot(resolvedUnits) {
+  return resolvedUnits.map((u) => ({
+    unitId: u.unitId,
+    owners: (u.owners || []).map(contactRowSnapshot),
+    managers: (u.managers || []).map(contactRowSnapshot),
+  }));
+}
+
+function contactRowSnapshot(c) {
+  if (!c || typeof c !== 'object') {
+    return { resolved: false, detail: String(c) };
+  }
+  const uid = getContactLinkedUserId(c);
+  const name = typeof c.name === 'string' ? c.name.trim() : '';
+  const email = typeof c.email === 'string' ? c.email.trim() : '';
+  return {
+    userId: uid || undefined,
+    name,
+    email,
+    resolved: Boolean(name || email),
+    missingLabelForLinkedUid: Boolean(uid) && !name && !email,
+  };
 }

--- a/functions/backend/utils/unitContactUtils.js
+++ b/functions/backend/utils/unitContactUtils.js
@@ -64,12 +64,13 @@ async function buildUserCache(userIds, db, existingCache = new Map()) {
 }
 
 /**
- * When Firestore user doc is missing or has no display label, fill from Firebase Auth
- * (displayName / email / phone). listUnits and other callers rely on this for NRM { userId } rows.
+ * Only fetch Firebase Auth when there is no Firestore `users/{uid}` document.
+ * Many SAMS accounts exist only in Firestore (contact-only / no Auth user); calling getUser for those
+ * UIDs fails with user-not-found and does not improve labels. Display names must come from Firestore
+ * via getDisplayNameFromUser when a doc exists.
  */
 export function needsAuthEnrichment(userData) {
-  if (!userData) return true;
-  return !getDisplayNameFromUser(userData);
+  return !userData;
 }
 
 /** Batch Firebase Auth lookups for UIDs (dedupe before calling). */
@@ -87,7 +88,12 @@ export async function buildFirebaseAuthCache(userIds) {
           phoneNumber: (rec.phoneNumber || '').trim()
         });
       } catch (e) {
-        logWarn(`Firebase Auth getUser failed for ${uid}: ${e.message}`);
+        const code = e?.code || e?.errorInfo?.code || '';
+        if (code === 'auth/user-not-found') {
+          logDebug(`Firebase Auth: no user for ${uid} (expected when uid has no Auth record)`);
+        } else {
+          logWarn(`Firebase Auth getUser failed for ${uid}: ${e.message}`);
+        }
         map.set(uid, null);
       }
     })

--- a/functions/backend/utils/unitContactUtils.js
+++ b/functions/backend/utils/unitContactUtils.js
@@ -8,6 +8,7 @@
  * Date: December 16, 2025
  */
 
+import admin from 'firebase-admin';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
 import { getDisplayNameFromUser as getDisplayNameFromUserShared } from '../../../shared/userIdentityDisplay.js';
 
@@ -62,7 +63,39 @@ async function buildUserCache(userIds, db, existingCache = new Map()) {
   return existingCache;
 }
 
-function resolveContactWithCache(contact, userCache) {
+/**
+ * When Firestore user doc is missing or has no display label, fill from Firebase Auth
+ * (displayName / email / phone). listUnits and other callers rely on this for NRM { userId } rows.
+ */
+export function needsAuthEnrichment(userData) {
+  if (!userData) return true;
+  return !getDisplayNameFromUser(userData);
+}
+
+/** Batch Firebase Auth lookups for UIDs (dedupe before calling). */
+export async function buildFirebaseAuthCache(userIds) {
+  const map = new Map();
+  if (!Array.isArray(userIds) || userIds.length === 0) return map;
+
+  await Promise.all(
+    userIds.map(async (uid) => {
+      try {
+        const rec = await admin.auth().getUser(uid);
+        map.set(uid, {
+          displayName: (rec.displayName || '').trim(),
+          email: (rec.email || '').trim(),
+          phoneNumber: (rec.phoneNumber || '').trim()
+        });
+      } catch (e) {
+        logWarn(`Firebase Auth getUser failed for ${uid}: ${e.message}`);
+        map.set(uid, null);
+      }
+    })
+  );
+  return map;
+}
+
+function resolveContactWithCache(contact, userCache, authCache = null) {
   // Normalize legacy string format to {name, email, phone} for consistent API response
   if (typeof contact === 'string') {
     const name = contact.trim();
@@ -77,16 +110,23 @@ function resolveContactWithCache(contact, userCache) {
     const userId = linkedId;
     const userData = userCache.get(userId);
 
-    if (!userData) {
-      // Keep unresolved UID entries backward-compatible for response shape.
-      return { userId, name: '', email: '', phone: '' };
+    let name = userData ? getDisplayNameFromUser(userData) : '';
+    let email = userData ? getEmailFromUser(userData) : '';
+    let phone = userData ? getPhoneFromUser(userData) : '';
+
+    const auth = authCache?.get(userId);
+    if (auth) {
+      if (!name && auth.displayName) name = auth.displayName;
+      if (!email && auth.email) email = auth.email;
+      if (!phone && auth.phoneNumber) phone = auth.phoneNumber;
     }
 
+    const displayName = name || email || '';
     return {
       userId,
-      name: getDisplayNameFromUser(userData),
-      email: getEmailFromUser(userData),
-      phone: getPhoneFromUser(userData),
+      name: displayName,
+      email,
+      phone: phone || ''
     };
   }
 
@@ -226,7 +266,7 @@ export async function buildUserCacheForUnits(units, db) {
  * @param {FirebaseFirestore.Firestore} db
  * @returns {Promise<Array<Object>>}
  */
-export async function resolveOwners(owners, db, existingCache = null) {
+export async function resolveOwners(owners, db, existingCache = null, prebuiltAuthCache = null) {
   if (!Array.isArray(owners) || owners.length === 0) {
     return [];
   }
@@ -239,7 +279,13 @@ export async function resolveOwners(owners, db, existingCache = null) {
   const userIds = getUniqueUserIds(owners);
   const userCache = await buildUserCache(userIds, db, existingCache || new Map());
 
-  return owners.map(owner => resolveContactWithCache(owner, userCache)).filter(Boolean);
+  const authCache =
+    prebuiltAuthCache ||
+    (await buildFirebaseAuthCache(
+      userIds.filter((uid) => needsAuthEnrichment(userCache.get(uid) || null))
+    ));
+
+  return owners.map(owner => resolveContactWithCache(owner, userCache, authCache)).filter(Boolean);
 }
 
 /**
@@ -250,7 +296,7 @@ export async function resolveOwners(owners, db, existingCache = null) {
  * @param {FirebaseFirestore.Firestore} db
  * @returns {Promise<Array<Object>>}
  */
-export async function resolveManagers(managers, db, existingCache = null) {
+export async function resolveManagers(managers, db, existingCache = null, prebuiltAuthCache = null) {
   if (!Array.isArray(managers) || managers.length === 0) {
     return [];
   }
@@ -263,7 +309,13 @@ export async function resolveManagers(managers, db, existingCache = null) {
   const userIds = getUniqueUserIds(managers);
   const userCache = await buildUserCache(userIds, db, existingCache || new Map());
 
-  return managers.map(manager => resolveContactWithCache(manager, userCache)).filter(Boolean);
+  const authCache =
+    prebuiltAuthCache ||
+    (await buildFirebaseAuthCache(
+      userIds.filter((uid) => needsAuthEnrichment(userCache.get(uid) || null))
+    ));
+
+  return managers.map(manager => resolveContactWithCache(manager, userCache, authCache)).filter(Boolean);
 }
 
 /**

--- a/shared/userIdentityDisplay.js
+++ b/shared/userIdentityDisplay.js
@@ -2,7 +2,16 @@
  * Canonical display-name resolution for SAMS user records (Firestore users collection shape).
  * Used by backend unit contact resolution and frontend owner/manager surfaces.
  *
- * Order: profile.firstName + profile.lastName, profile.displayName, contactName, name, displayName, email (last resort for labels).
+ * Precedence when multiple fields are populated (see userManagementController createUser / updateUser):
+ * — Display label (getDisplayNameFromUser): **current (NRM) profile first**, then legacy scalars.
+ *   1. profile.firstName + profile.lastName (structured name from create/update)
+ *   2. profile.displayName
+ *   3. name, displayName (root — updated by updateUser / createUser)
+ *   4. contactName (older legacy)
+ *   5. root email, then profile.email (use as label only when no name)
+ * — Email (getCanonicalEmailFromUser): **root email** (source in createUser), then profile.email (legacy).
+ * — Phone (getCanonicalPhoneFromUser): **profile.phone** (source in createUser), then root phone (legacy).
+ *
  * Non-string field values are coerced (Firestore may store legacy scalars).
  */
 
@@ -25,17 +34,42 @@ export function getDisplayNameFromUser(userData = {}) {
   const profileDisplayName = strField(profile.displayName);
   if (profileDisplayName) return profileDisplayName;
 
-  const contactName = strField(userData.contactName);
-  if (contactName) return contactName;
-
   const name = strField(userData.name);
   if (name) return name;
 
   const displayName = strField(userData.displayName);
   if (displayName) return displayName;
 
+  const contactName = strField(userData.contactName);
+  if (contactName) return contactName;
+
   const email = strField(userData.email);
   if (email) return email;
 
+  const profileEmail = strField(profile.email);
+  if (profileEmail) return profileEmail;
+
   return '';
+}
+
+/**
+ * Contact/login email for API responses: root `email` (createUser / Auth-aligned), then `profile.email` (legacy).
+ */
+export function getCanonicalEmailFromUser(userData = {}) {
+  if (!userData || typeof userData !== 'object') return '';
+  const root = strField(userData.email);
+  if (root) return root;
+  const profile = userData.profile || {};
+  return strField(profile.email);
+}
+
+/**
+ * Phone for API responses: `profile.phone` (createUser), then root `phone` (legacy).
+ */
+export function getCanonicalPhoneFromUser(userData = {}) {
+  if (!userData || typeof userData !== 'object') return '';
+  const profile = userData.profile || {};
+  const fromProfile = strField(profile.phone);
+  if (fromProfile) return fromProfile;
+  return strField(userData.phone);
 }

--- a/shared/userIdentityDisplay.js
+++ b/shared/userIdentityDisplay.js
@@ -2,7 +2,7 @@
  * Canonical display-name resolution for SAMS user records (Firestore users collection shape).
  * Used by backend unit contact resolution and frontend owner/manager surfaces.
  *
- * Order: profile.firstName + profile.lastName, name, displayName, email (last resort for labels).
+ * Order: profile.firstName + profile.lastName, profile.displayName, name, displayName, email (last resort for labels).
  */
 
 export function getDisplayNameFromUser(userData = {}) {
@@ -13,6 +13,9 @@ export function getDisplayNameFromUser(userData = {}) {
   const lastName = typeof profile.lastName === 'string' ? profile.lastName.trim() : '';
   const fullName = `${firstName} ${lastName}`.trim();
   if (fullName) return fullName;
+
+  const profileDisplayName = typeof profile.displayName === 'string' ? profile.displayName.trim() : '';
+  if (profileDisplayName) return profileDisplayName;
 
   if (typeof userData.name === 'string' && userData.name.trim()) {
     return userData.name.trim();

--- a/shared/userIdentityDisplay.js
+++ b/shared/userIdentityDisplay.js
@@ -17,6 +17,9 @@ export function getDisplayNameFromUser(userData = {}) {
   const profileDisplayName = typeof profile.displayName === 'string' ? profile.displayName.trim() : '';
   if (profileDisplayName) return profileDisplayName;
 
+  const contactName = typeof userData.contactName === 'string' ? userData.contactName.trim() : '';
+  if (contactName) return contactName;
+
   if (typeof userData.name === 'string' && userData.name.trim()) {
     return userData.name.trim();
   }

--- a/shared/userIdentityDisplay.js
+++ b/shared/userIdentityDisplay.js
@@ -2,32 +2,40 @@
  * Canonical display-name resolution for SAMS user records (Firestore users collection shape).
  * Used by backend unit contact resolution and frontend owner/manager surfaces.
  *
- * Order: profile.firstName + profile.lastName, profile.displayName, name, displayName, email (last resort for labels).
+ * Order: profile.firstName + profile.lastName, profile.displayName, contactName, name, displayName, email (last resort for labels).
+ * Non-string field values are coerced (Firestore may store legacy scalars).
  */
+
+function strField(v) {
+  if (v == null || v === '') return '';
+  if (typeof v === 'string') return v.trim();
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v).trim();
+  return '';
+}
 
 export function getDisplayNameFromUser(userData = {}) {
   if (!userData || typeof userData !== 'object') return '';
 
   const profile = userData.profile || {};
-  const firstName = typeof profile.firstName === 'string' ? profile.firstName.trim() : '';
-  const lastName = typeof profile.lastName === 'string' ? profile.lastName.trim() : '';
+  const firstName = strField(profile.firstName);
+  const lastName = strField(profile.lastName);
   const fullName = `${firstName} ${lastName}`.trim();
   if (fullName) return fullName;
 
-  const profileDisplayName = typeof profile.displayName === 'string' ? profile.displayName.trim() : '';
+  const profileDisplayName = strField(profile.displayName);
   if (profileDisplayName) return profileDisplayName;
 
-  const contactName = typeof userData.contactName === 'string' ? userData.contactName.trim() : '';
+  const contactName = strField(userData.contactName);
   if (contactName) return contactName;
 
-  if (typeof userData.name === 'string' && userData.name.trim()) {
-    return userData.name.trim();
-  }
-  if (typeof userData.displayName === 'string' && userData.displayName.trim()) {
-    return userData.displayName.trim();
-  }
-  if (typeof userData.email === 'string' && userData.email.trim()) {
-    return userData.email.trim();
-  }
+  const name = strField(userData.name);
+  if (name) return name;
+
+  const displayName = strField(userData.displayName);
+  if (displayName) return displayName;
+
+  const email = strField(userData.email);
+  if (email) return email;
+
   return '';
 }

--- a/shared/userIdentityDisplay.js
+++ b/shared/userIdentityDisplay.js
@@ -1,0 +1,27 @@
+/**
+ * Canonical display-name resolution for SAMS user records (Firestore users collection shape).
+ * Used by backend unit contact resolution and frontend owner/manager surfaces.
+ *
+ * Order: profile.firstName + profile.lastName, name, displayName, email (last resort for labels).
+ */
+
+export function getDisplayNameFromUser(userData = {}) {
+  if (!userData || typeof userData !== 'object') return '';
+
+  const profile = userData.profile || {};
+  const firstName = typeof profile.firstName === 'string' ? profile.firstName.trim() : '';
+  const lastName = typeof profile.lastName === 'string' ? profile.lastName.trim() : '';
+  const fullName = `${firstName} ${lastName}`.trim();
+  if (fullName) return fullName;
+
+  if (typeof userData.name === 'string' && userData.name.trim()) {
+    return userData.name.trim();
+  }
+  if (typeof userData.displayName === 'string' && userData.displayName.trim()) {
+    return userData.displayName.trim();
+  }
+  if (typeof userData.email === 'string' && userData.email.trim()) {
+    return userData.email.trim();
+  }
+  return '';
+}


### PR DESCRIPTION
## Summary
Closes / addresses **#272** — owner/manager names missing in HOA Dues and List Management.

## Canonical path
- **`shared/userIdentityDisplay.js`** — `getDisplayNameFromUser`: `profile.firstName`+`lastName`, then `name`, `displayName`, then `email`.
- **Backend** `functions/backend/utils/unitContactUtils.js` re-exports the shared helper so `listUnits` / `resolveOwners` / `resolveManagers` enrich `{ userId }` contacts consistently.
- **Frontend** `unitContactUtils.js` imports the same module; **`resolvedContactLabel`** is the single helper for API-shaped owner/manager rows (name, then email).
- **`normalizeOwners` / `normalizeManagers`** keep `{ userId }` rows instead of dropping them when `name` is empty (previously filtered out).

## Test evidence
- `bash scripts/pre-pr-checks.sh main` — pass (4 frontend files on this branch vs main).
- Manual: verify HOA Dues unit header / tooltip and List Management unit detail show names for users that only had Firebase `displayName` or email on the user document.

## Risks / follow-up
- Mobile `unitContactUtils` still diverges slightly; consider importing shared helper in a follow-up for parity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how unit owner/manager contacts are resolved and displayed across backend and frontend, and adds an optional diagnostics payload to the units listing endpoint; issues could surface as missing/changed labels in UI or exports.
> 
> **Overview**
> Fixes missing owner/manager names by introducing a **shared canonical identity resolver** (`shared/userIdentityDisplay.js`) and using it end-to-end for unit contact display.
> 
> Backend unit listing now batch-loads linked `users/{uid}` docs, resolves owners/managers via a single `resolveUnitContactsForApi` helper (accepting legacy `uid` as well as `userId`), and optionally returns `contactDiagnostics` when `GET /clients/:clientId/units?contactDiagnostics=1` is used.
> 
> Frontend updates unit contact utilities and unit/HOA dues/list-management views to use a single `resolvedContactLabel` (name → email fallback), preserve UID-only contact rows during normalization, and clean up noisy debug logging; unit exports now reuse the same owner/manager name helpers for consistent CSV output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b907dc36059e3eb856796701f9b14dca9bfb0b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->