### PR TITLE
fix(#246): unit assignment picker — all admin-visible users (cross-client)

### DIFF
--- a/frontend/sams-ui/src/api/user.js
+++ b/frontend/sams-ui/src/api/user.js
@@ -102,6 +102,25 @@ export const userAPI = {
   },
 
   /**
+   * All users visible to the current admin (same source as User Management list).
+   * Used for unit owner/manager assignment across clients (#246).
+   */
+  async getSystemUsers() {
+    try {
+      const headers = await getAuthHeaders();
+      const response = await fetch(`${API_BASE_URL}/admin/users`, {
+        method: 'GET',
+        headers
+      });
+      const result = await handleApiResponse(response);
+      return result.users || [];
+    } catch (error) {
+      console.error('Failed to fetch system users:', error);
+      throw new Error(`Failed to load users: ${error.message}`);
+    }
+  },
+
+  /**
    * Update user propertyAccess for a specific client
    * @param {string} userId - The user ID to update
    * @param {string} clientId - The client ID

--- a/frontend/sams-ui/src/components/common/UserPicker.jsx
+++ b/frontend/sams-ui/src/components/common/UserPicker.jsx
@@ -1,25 +1,23 @@
 import React, { useState, useEffect } from 'react';
 import { useSecureApi } from '../../api/secureApiClient.js';
+import { getDisplayNameFromUser } from '../../utils/unitContactUtils.js';
 
 /**
  * UserPicker Component
  * Displays a dropdown to select users from the Users collection
  * Filters users by client and optionally by role
- * 
- * @param {string} clientId - The client ID to filter users by
- * @param {string} selectedUserId - Currently selected user ID (or null)
- * @param {Function} onSelect - Callback when user is selected (userId) => void
- * @param {Array<string>} allowedRoles - Optional array of roles to filter by (e.g., ['unitOwner', 'unitManager'])
- * @param {string} label - Label for the picker
- * @param {boolean} required - Whether selection is required
+ *
+ * @param {string} clientId - The client ID to filter users by (when requirePropertyAccessForClient is true)
+ * @param {boolean} requirePropertyAccessForClient - If false, list all system users (unit assignment / cross-client)
  */
-const UserPicker = ({ 
-  clientId, 
-  selectedUserId, 
-  onSelect, 
-  allowedRoles = null, 
+const UserPicker = ({
+  clientId,
+  selectedUserId,
+  onSelect,
+  allowedRoles = null,
   label = 'User',
-  required = false 
+  required = false,
+  requirePropertyAccessForClient = true
 }) => {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -31,49 +29,23 @@ const UserPicker = ({
       try {
         setLoading(true);
         setError(null);
-        
-        // Use same approach as UserManagement - fetch all users, then filter on frontend
+
         const response = await secureApi.getSystemUsers();
         const allUsers = response.users || [];
-        
-        console.log(`🔍 UserPicker: Fetched ${allUsers.length} total users`);
-        
-        // Filter by clientId if provided
+
         let filtered = allUsers;
-        if (clientId) {
-          filtered = allUsers.filter(user => {
-            const hasAccess = user.propertyAccess?.[clientId] != null;
-            if (!hasAccess && user.email) {
-              console.log(`  ⚠️  User ${user.email} (${user.id}) does not have propertyAccess for ${clientId}`);
-            }
-            return hasAccess;
-          });
-          console.log(`📊 UserPicker: ${filtered.length} users have access to clientId: ${clientId}`);
+        if (clientId && requirePropertyAccessForClient) {
+          filtered = allUsers.filter(user => user.propertyAccess?.[clientId] != null);
         }
-        
-        // Filter by roles if specified
-        if (allowedRoles && allowedRoles.length > 0) {
+
+        if (allowedRoles && allowedRoles.length > 0 && clientId) {
           filtered = filtered.filter(user => {
             const access = user.propertyAccess?.[clientId];
-            if (!access) {
-              if (user.email) {
-                console.log(`  ⚠️  User ${user.email} (${user.id}) - no propertyAccess for ${clientId}`);
-              }
-              return false;
-            }
-            
-            const userRole = access.role;
-            const hasRole = allowedRoles.includes(userRole);
-            
-            if (!hasRole && user.email) {
-              console.log(`  ⚠️  User ${user.email} (${user.id}) - role: "${userRole}", needs one of:`, allowedRoles);
-            }
-            
-            return hasRole;
+            if (!access) return false;
+            return allowedRoles.includes(access.role);
           });
-          console.log(`✅ UserPicker: Filtered to ${filtered.length} users with roles:`, allowedRoles);
         }
-        
+
         setUsers(filtered);
       } catch (err) {
         console.error('Error fetching users:', err);
@@ -84,7 +56,7 @@ const UserPicker = ({
     };
 
     fetchUsers();
-  }, [clientId, allowedRoles, secureApi]);
+  }, [clientId, allowedRoles, secureApi, requirePropertyAccessForClient]);
 
   if (loading) {
     return (
@@ -113,7 +85,9 @@ const UserPicker = ({
       <div className="user-picker">
         <label>{label}{required && ' *'}</label>
         <select disabled>
-          <option>No users available for this client</option>
+          <option>
+            {requirePropertyAccessForClient ? 'No users available for this client' : 'No users available'}
+          </option>
         </select>
         <span className="sandyland-helper-text">
           No users found. Create users in User Management first.
@@ -125,8 +99,8 @@ const UserPicker = ({
   return (
     <div className="user-picker">
       <label>{label}{required && ' *'}</label>
-      <select 
-        value={selectedUserId || ''} 
+      <select
+        value={selectedUserId || ''}
         onChange={(e) => onSelect(e.target.value || null)}
         required={required}
         style={{ width: '100%', padding: '8px', fontSize: '14px' }}
@@ -134,7 +108,7 @@ const UserPicker = ({
         <option value="">-- Select {label} --</option>
         {users.map(user => (
           <option key={user.id} value={user.id}>
-            {user.name || user.displayName || user.email} ({user.email})
+            {getDisplayNameFromUser(user) || user.email || user.id} ({user.email || 'no email'})
           </option>
         ))}
       </select>
@@ -143,4 +117,3 @@ const UserPicker = ({
 };
 
 export default UserPicker;
-

--- a/frontend/sams-ui/src/components/modals/UnitFormModal.jsx
+++ b/frontend/sams-ui/src/components/modals/UnitFormModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useClient } from '../../context/ClientContext';
-import { normalizeOwners, normalizeManagers } from '../../utils/unitContactUtils.js';
+import { normalizeOwners, normalizeManagers, getDisplayNameFromUser } from '../../utils/unitContactUtils.js';
 import UserPicker from '../common/UserPicker.jsx';
 import { userAPI } from '../../api/user.js';
 import '../../styles/SandylandModalTheme.css';
@@ -93,7 +93,7 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
         // Match owners to users by email
         if (ownersWithIds.length > 0) {
           try {
-            const users = await userAPI.getUsersByClient(selectedClient.id);
+            const users = await userAPI.getSystemUsers();
             ownersWithIds = ownersWithIds.map(owner => {
               // If userId already exists, keep it
               if (owner.userId) return owner;
@@ -120,7 +120,7 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
         // Match managers to users by email
         if (managersWithIds.length > 0) {
           try {
-            const users = await userAPI.getUsersByClient(selectedClient.id);
+            const users = await userAPI.getSystemUsers();
             managersWithIds = managersWithIds.map(manager => {
               // If userId already exists, keep it
               if (manager.userId) return manager;
@@ -338,11 +338,11 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
     if (userId) {
       // When a user is selected, fetch user data and populate name/email
       try {
-        const users = await userAPI.getUsersByClient(selectedClient.id);
+        const users = await userAPI.getSystemUsers();
         const selectedUser = users.find(u => u.id === userId);
         if (selectedUser) {
           newOwners[index] = {
-            name: selectedUser.name || selectedUser.displayName || selectedUser.email || '',
+            name: getDisplayNameFromUser(selectedUser) || selectedUser.email || '',
             email: selectedUser.email || '',
             userId: userId
           };
@@ -389,11 +389,11 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
     if (userId) {
       // When a user is selected, fetch user data and populate name/email
       try {
-        const users = await userAPI.getUsersByClient(selectedClient.id);
+        const users = await userAPI.getSystemUsers();
         const selectedUser = users.find(u => u.id === userId);
         if (selectedUser) {
           newManagers[index] = {
-            name: selectedUser.name || selectedUser.displayName || selectedUser.email || '',
+            name: getDisplayNameFromUser(selectedUser) || selectedUser.email || '',
             email: selectedUser.email || '',
             userId: userId
           };
@@ -584,6 +584,7 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
                           allowedRoles={null}
                           label="Owner"
                           required={index === 0}
+                          requirePropertyAccessForClient={false}
                         />
                       </div>
                       <button
@@ -626,6 +627,7 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
                               allowedRoles={null}
                               label="Manager"
                               required={false}
+                              requirePropertyAccessForClient={false}
                             />
                           </div>
                           <button


### PR DESCRIPTION
## Summary
Addresses **#246** — unit owner/manager picker only listed users who already had `propertyAccess` for the current client.

## Canonical path
- Same as **#272**: `getDisplayNameFromUser` from `shared/userIdentityDisplay.js` (via `unitContactUtils`) for picker option labels.
- **`userAPI.getSystemUsers()`** — `GET /admin/users` without `clientId` (same source as User Management list).
- **`UserPicker`**: new prop `requirePropertyAccessForClient` (default **true** for backward compatibility). Unit form passes **`false`** so admins can assign users who will receive `propertyAccess` on save.
- **`UnitFormModal`**: resolves selected users via `getSystemUsers()` + canonical display name.

## Stacked PR
**Base branch is `fix/272-owner-manager-name-resolution`.** After #272 merges to `main`, edit this PR to set **base = `main`** (or rebase this branch onto `main`).

## Test evidence
- `bash scripts/pre-pr-checks.sh main` — pass when comparing `fix/246` to `main` (7 frontend files).
- Manual role matrix: SuperAdmin/Admin — open Add/Edit Unit, confirm users **without** prior access to the selected client appear in Owner/Manager pickers; save still syncs `propertyAccess`.

## Regression
- Other `UserPicker` call sites keep default `requirePropertyAccessForClient={true}`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-fetching/filtering for unit owner/manager assignment to use the full `/admin/users` list, which can affect who can be assigned and increases reliance on admin-scoped permissions and payload size.
> 
> **Overview**
> Unit owner/manager assignment now pulls from the full admin-visible user list (cross-client) instead of only users with existing `propertyAccess` for the selected client.
> 
> This adds `userAPI.getSystemUsers()` (GET ` /admin/users`), updates `UserPicker` with a `requirePropertyAccessForClient` flag (defaulting to current behavior), and updates `UnitFormModal` to use cross-client pickers plus canonical `getDisplayNameFromUser` labeling when populating contacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c8ffb0315ef8a6694df59a0ecdbafa98926c2b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->