### PR TITLE
fix(ui): prevent duplicate bank fee/IVA on split expense edit (#271)

### DIFF
--- a/frontend/sams-ui/src/components/UnifiedExpenseEntry.jsx
+++ b/frontend/sams-ui/src/components/UnifiedExpenseEntry.jsx
@@ -17,6 +17,23 @@ import { getMexicoDateString } from '../utils/timezone';
 import { databaseFieldMappings } from '../utils/databaseFieldMappings';
 import './UnifiedExpenseEntry.css';
 
+/**
+ * True when split rows already include the standard bank transfer fee + IVA lines.
+ * Prevents re-pushing fee allocations and re-subtracting fee from total on edit (Issue #271).
+ */
+function splitAllocationsAlreadyIncludeBankFees(allocations) {
+  if (!Array.isArray(allocations) || allocations.length < 2) return false;
+  let hasFeeLine = false;
+  let hasIvaLine = false;
+  for (const a of allocations) {
+    const cat = String(a.categoryName || '').trim();
+    const notes = String(a.notes || '').trim();
+    if (cat === 'Bank: Transfer Fees' || notes === 'Bank transfer fee') hasFeeLine = true;
+    if (cat === 'Bank: IVA' || notes === 'Bank transfer IVA') hasIvaLine = true;
+  }
+  return hasFeeLine && hasIvaLine;
+}
+
 const UnifiedExpenseEntry = ({ 
   mode = 'modal', // 'modal' or 'screen'
   isOpen = true,
@@ -296,8 +313,10 @@ const UnifiedExpenseEntry = ({
             amount: databaseFieldMappings.centsToDollars(allocation.amount || 0),
             notes: allocation.notes || ''
           }));
-          
-          if (addBankFees) {
+
+          // Issue #271: On edit, fee+IVA rows are already in splitAllocations; do not append again or adjust amount twice.
+          const bankFeesAlreadyInSplit = splitAllocationsAlreadyIncludeBankFees(splitAllocations);
+          if (addBankFees && !bankFeesAlreadyInSplit) {
             const commissionAmountDollars = 5.00;
             const ivaAmountDollars = 0.80;
             apiAllocations.push(


### PR DESCRIPTION
## Summary
- Prevent duplicate bank fee/IVA append on split transaction **edit** when fee lines already exist in `splitAllocations`
- Avoid second amount adjustment in the same edit path by guarding the fee block with an existing-fee detector
- Keep change scoped to `UnifiedExpenseEntry` submit flow only

## Test plan
- [x] `bash scripts/pre-pr-checks.sh main`
- [ ] Manual desktop edit cycles on live data (required before merge):
  - Edit existing fee+IVA split once and multiple times; verify no duplicate fee rows and no total drift
  - Verify no-fee expense edit unchanged
  - Verify split without fee lines still appends fees once when checkbox is checked

## Notes
- This PR replaces closed stale PR #278 from the parallel-run cleanup.
- Manual evidence is still required before issue closure/merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches expense submission logic that affects split allocations and transaction totals; incorrect detection could impact displayed/stored amounts for bank-fee split edits.
> 
> **Overview**
> Prevents duplicate bank transfer fee/IVA lines and double-adjusted totals when editing split expenses with *Add Bank Fees* enabled.
> 
> Adds a helper (`splitAllocationsAlreadyIncludeBankFees`) and guards the submit-time fee append/amount adjustment so fees are only added when those standard fee rows are not already present in `splitAllocations` (Issue #271).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc991fa7f1e5cf33cc4ec8861b7e3c539609753c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->