### PR TITLE
fix(auth): HTML-safe temporary password charset (#275)

### DIFF
--- a/functions/backend/controllers/userManagementController.js
+++ b/functions/backend/controllers/userManagementController.js
@@ -14,18 +14,7 @@ import { isSystemSchedulerAccount } from '../utils/systemSchedulerAccount.js';
 import { sendPasswordNotification } from '../services/emailService.js';
 import { getNow } from '../services/DateService.js';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
-
-/**
- * Generate secure random password
- */
-function generateSecurePassword() {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
-  let password = '';
-  for (let i = 0; i < 12; i++) {
-    password += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return password;
-}
+import { generateSecureTempPassword } from '../../shared/utils/tempPassword.js';
 
 /**
  * Add person to unit's arrays based on their role
@@ -341,7 +330,7 @@ export async function createUser(req, res) {
       
       if (!canLogin) {
         // Create disabled Firebase Auth user (contact-only)
-        temporaryPassword = generateSecurePassword(); // Required but never used
+        temporaryPassword = generateSecureTempPassword(); // Required but never used
         userRecord = await admin.auth().createUser({
           email: email,
           password: temporaryPassword,
@@ -352,7 +341,7 @@ export async function createUser(req, res) {
         accountState = 'contact_only';
       } else if (creationMethod === 'passkey') {
         // Create user for passkey flow — no email sent; admin generates invite URL
-        temporaryPassword = generateSecurePassword();
+        temporaryPassword = generateSecureTempPassword();
         userRecord = await admin.auth().createUser({
           email: email,
           password: temporaryPassword,
@@ -363,7 +352,7 @@ export async function createUser(req, res) {
         accountState = 'pending_passkey';
       } else {
         // Create active user with temporary password for manual flow
-        temporaryPassword = generateSecurePassword();
+        temporaryPassword = generateSecureTempPassword();
         userRecord = await admin.auth().createUser({
           email: email,
           password: temporaryPassword,
@@ -713,7 +702,7 @@ export async function updateUser(req, res) {
       // Handle password reset for self
       if (resetPassword) {
         try {
-          const passwordToSet = newPassword || generateSecurePassword();
+          const passwordToSet = newPassword || generateSecureTempPassword();
           await admin.auth().updateUser(userId, {
             password: passwordToSet,
             disabled: false
@@ -838,7 +827,7 @@ export async function updateUser(req, res) {
         await admin.auth().updateUser(userId, { disabled: false });
         
         // Generate temporary password and send notification
-        const tempPassword = generateSecurePassword();
+        const tempPassword = generateSecureTempPassword();
         await admin.auth().updateUser(userId, { password: tempPassword });
         
         await sendPasswordNotification({
@@ -917,7 +906,7 @@ export async function updateUser(req, res) {
     // Handle password reset if requested
     if (resetPassword) {
       try {
-        const passwordToSet = newPassword || generateSecurePassword();
+        const passwordToSet = newPassword || generateSecureTempPassword();
         await admin.auth().updateUser(userId, {
           password: passwordToSet,
           disabled: false // Ensure user is enabled when resetting password

--- a/functions/backend/routes/auth.js
+++ b/functions/backend/routes/auth.js
@@ -9,20 +9,9 @@ import admin from 'firebase-admin';
 import { sendPasswordNotification } from '../services/emailService.js';
 import { getNow } from '../services/DateService.js';
 import { isSystemSchedulerAccount } from '../utils/systemSchedulerAccount.js';
+import { generateSecureTempPassword } from '../../shared/utils/tempPassword.js';
 
 const router = express.Router();
-
-/**
- * Generate secure random password
- */
-function generateSecurePassword() {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*';
-  let password = '';
-  for (let i = 0; i < 12; i++) {
-    password += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return password;
-}
 
 /**
  * Reset password for forgotten password requests
@@ -81,7 +70,7 @@ router.post('/reset-password', async (req, res) => {
     }
 
     // Generate temporary password
-    const temporaryPassword = generateSecurePassword();
+    const temporaryPassword = generateSecureTempPassword();
 
     // Update Firebase Auth with temporary password
     await admin.auth().updateUser(userRecord.uid, {

--- a/functions/shared/utils/__tests__/tempPassword.test.js
+++ b/functions/shared/utils/__tests__/tempPassword.test.js
@@ -1,0 +1,41 @@
+/**
+ * Charset / generation checks for issue #275 (HTML-safe temp passwords).
+ * Run: node --test functions/shared/utils/__tests__/tempPassword.test.js
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  TEMP_PASSWORD_CHARSET,
+  generateSecureTempPassword
+} from '../tempPassword.js';
+
+const BLOCKED = ['&', '#'];
+
+describe('tempPassword', () => {
+  it('charset excludes & and #', () => {
+    for (const ch of BLOCKED) {
+      assert.ok(!TEMP_PASSWORD_CHARSET.includes(ch), `must not include ${ch}`);
+    }
+  });
+
+  it('generated passwords use only charset and default length 12', () => {
+    for (let i = 0; i < 500; i++) {
+      const p = generateSecureTempPassword();
+      assert.strictEqual(p.length, 12);
+      for (const ch of p) {
+        assert.ok(
+          TEMP_PASSWORD_CHARSET.includes(ch),
+          `unexpected char ${ch} in ${p}`
+        );
+      }
+      for (const b of BLOCKED) {
+        assert.ok(!p.includes(b), `blocked ${b} in ${p}`);
+      }
+    }
+  });
+
+  it('respects custom length', () => {
+    assert.strictEqual(generateSecureTempPassword(8).length, 8);
+  });
+});

--- a/functions/shared/utils/tempPassword.js
+++ b/functions/shared/utils/tempPassword.js
@@ -1,0 +1,27 @@
+/**
+ * Temporary password generation for SAMS (issue #275).
+ * Charset excludes HTML-dangerous characters at minimum: & and # (email/template safety).
+ * Uses crypto.randomInt for uniform selection (Node 12+).
+ */
+
+import crypto from 'crypto';
+
+/** Allowed characters for temp passwords shown in HTML email and UI. */
+export const TEMP_PASSWORD_CHARSET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@$%^*';
+
+/**
+ * @param {number} [length=12]
+ * @returns {string}
+ */
+export function generateSecureTempPassword(length = 12) {
+  if (length < 1) {
+    throw new RangeError('generateSecureTempPassword: length must be >= 1');
+  }
+  const n = TEMP_PASSWORD_CHARSET.length;
+  let password = '';
+  for (let i = 0; i < length; i++) {
+    password += TEMP_PASSWORD_CHARSET.charAt(crypto.randomInt(0, n));
+  }
+  return password;
+}

--- a/scripts/client-onboarding/create-firebase-users.js
+++ b/scripts/client-onboarding/create-firebase-users.js
@@ -15,6 +15,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import crypto from 'crypto';
+import { generateSecureTempPassword } from '../../functions/shared/utils/tempPassword.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -63,30 +64,6 @@ async function getLatestMigrationDir(clientId) {
   
   return path.join(migrationsDir, clientDirs[0]);
 }
-
-// Generate a secure temporary password
-function generateTempPassword() {
-  // Generate a password that meets Firebase requirements:
-  // - At least 6 characters
-  // - Mix of letters, numbers, and special characters
-  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%^&*';
-  let password = '';
-  
-  // Ensure at least one of each type
-  password += 'A'; // uppercase
-  password += 'a'; // lowercase
-  password += '2'; // number
-  password += '!'; // special
-  
-  // Add random characters to reach 12 characters total
-  for (let i = 0; i < 8; i++) {
-    password += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  
-  // Shuffle the password
-  return password.split('').sort(() => Math.random() - 0.5).join('');
-}
-
 
 // Main function
 async function main() {
@@ -148,7 +125,7 @@ async function main() {
           existingUsers.push(email);
         } catch (error) {
           // User doesn't exist, create them
-          const tempPassword = generateTempPassword();
+          const tempPassword = generateSecureTempPassword();
           
           const createRequest = {
             email: email,

--- a/scripts/create-standardized-user.js
+++ b/scripts/create-standardized-user.js
@@ -15,6 +15,7 @@ import { getAuth } from 'firebase-admin/auth';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { generateSecureTempPassword } from '../functions/shared/utils/tempPassword.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -191,7 +192,7 @@ async function createUser(userData) {
     // 2. Create Firebase Auth user
     const authUser = await auth.createUser({
       email: userData.email,
-      password: userData.password || generateTempPassword(),
+      password: userData.password || generateSecureTempPassword(),
       displayName: `${userData.firstName} ${userData.lastName}`
     });
     
@@ -218,18 +219,6 @@ async function createUser(userData) {
       error: error.message
     };
   }
-}
-
-/**
- * Generate a temporary password
- */
-function generateTempPassword() {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%';
-  let password = '';
-  for (let i = 0; i < 12; i++) {
-    password += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return password;
 }
 
 // Show examples

--- a/scripts/reconcile-auth-users.js
+++ b/scripts/reconcile-auth-users.js
@@ -14,7 +14,7 @@
 
 import admin from 'firebase-admin';
 import { createInterface } from 'readline';
-import { randomBytes } from 'crypto';
+import { generateSecureTempPassword } from '../functions/shared/utils/tempPassword.js';
 
 // ── CLI Argument Parsing ─────────────────────────────────────────────────────
 
@@ -72,10 +72,6 @@ const db = (() => { initFirebase(); return admin.firestore(); })();
 const auth = admin.auth();
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function generateTempPassword() {
-  return randomBytes(24).toString('base64url');
-}
 
 function prompt(question) {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -369,7 +365,7 @@ async function runFix(orphanedUsers) {
     const { docId, email, displayName } = user;
     try {
       // Step 1: Create Firebase Auth record with the same UID
-      const tempPassword = generateTempPassword();
+      const tempPassword = generateSecureTempPassword();
       await auth.createUser({
         uid: docId,
         email,


### PR DESCRIPTION
## Summary
Temporary passwords for forgot-password, user creation, and admin reset flows use a shared generator that excludes HTML-dangerous characters (at minimum `&` and `#`) so values match between Firebase Auth and HTML/plaintext email.

## Changes
- `functions/shared/utils/tempPassword.js` — `generateSecureTempPassword()`, `crypto.randomInt`, documented charset
- `functions/backend/routes/auth.js` and `userManagementController.js` — import shared generator
- Ops scripts (`reconcile-auth-users.js`, `create-firebase-users.js`, `create-standardized-user.js`) — use shared generator
- `functions/shared/utils/__tests__/tempPassword.test.js` — charset + sampling tests

## Testing
- `node --test functions/shared/utils/__tests__/tempPassword.test.js` — pass
- Manual: send preview email + login + invalid password (staging) — recommended before merge

Closes #275

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches password generation used by user creation and reset flows; while logic is simple, any regression could impact login/password-reset reliability across the system.
> 
> **Overview**
> Introduces a shared `generateSecureTempPassword()` utility (with a restricted, HTML-safe charset excluding `&` and `#`, and `crypto.randomInt`-based selection) plus unit tests for charset/length guarantees.
> 
> Replaces multiple ad-hoc temporary password generators across backend user management, the public forgot-password route, and several ops/onboarding scripts to consistently use the shared generator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2284ccf9f6b55727f7e7e0205909727c4ba436ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->