### PR TITLE
fix(soa): AVII water mini-graph — prior 6 months, fixed six-bar layout (#260)

### DIFF
--- a/functions/backend/services/statementDataService.js
+++ b/functions/backend/services/statementDataService.js
@@ -30,9 +30,10 @@ import { isFeatureEnabled } from '../utils/featureFlags.js';
  * @param {string} clientId - Client ID (e.g., 'MTC', 'AVII')
  * @param {string} unitId - Unit ID (e.g., '101', '1A')
  * @param {number} fiscalYearStartMonth - Fiscal year start month (1-12) for month label formatting
+ * @param {number|null} fiscalYear - Statement fiscal year (limits water bars to that FY; null = legacy rolling window)
  * @returns {Promise<Object|null>} Utility graph data or null if no data available
  */
-async function getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth = 7) {
+async function getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth = 7, fiscalYear = null) {
   try {
     // Check client config to determine graph type
     const configDoc = await db
@@ -46,7 +47,7 @@ async function getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth = 
     }
     
     // AVII: Water consumption bars
-    return await getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth);
+    return await getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth, fiscalYear);
   } catch (error) {
     logError(`❌ [Utility Graph] Error fetching utility graph data for ${clientId}/${unitId}:`, error);
     return null;
@@ -119,9 +120,10 @@ async function getPropaneGaugeData(db, clientId, unitId, config) {
  * @param {string} clientId - Client ID (should be 'AVII')
  * @param {string} unitId - Unit ID
  * @param {number} fiscalYearStartMonth - Fiscal year start month (1-12) for month label formatting
+ * @param {number|null} fiscalYear - Statement fiscal year (filter periods to this FY before taking last 6)
  * @returns {Promise<Object|null>} Water bars data or null
  */
-async function getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth = 7) {
+async function getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth = 7, fiscalYear = null) {
   try {
     // Get all water readings (no orderBy to avoid index requirement)
     // We'll sort in memory to find consecutive months
@@ -197,9 +199,15 @@ async function getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth = 7) 
       priorReading = currentReading;
     }
     
-    // Take last 6-8 periods (most recent)
-    const recentPeriods = periods.slice(-8);
-    
+    // SoA mini-graph: last 6 consumption months within the statement fiscal year (#260).
+    // Reading docs use fiscal `year` + fiscal month index 0–11 (waterReadingsService).
+    // Six bars + dynamic SVG width avoids viewBox clipping when more months were shown.
+    let fyPeriods = periods;
+    if (fiscalYear != null && !Number.isNaN(Number(fiscalYear))) {
+      const fy = Number(fiscalYear);
+      fyPeriods = periods.filter(p => Number(p.year) === fy);
+    }
+    const recentPeriods = fyPeriods.slice(-6);
     if (recentPeriods.length === 0) {
       return null;
     }
@@ -2905,7 +2913,8 @@ export async function getStatementData(api, clientId, unitId, fiscalYear = null,
     const db = await getDb();
     // Pass fiscal year start month for proper month label formatting
     const fiscalYearStartMonth = rawData.clientConfig?.fiscalYearStartMonth || 7; // Default to July for AVII
-    utilityGraph = await getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth);
+    const statementFiscalYear = rawData.clientConfig?.fiscalYear ?? null;
+    utilityGraph = await getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth, statementFiscalYear);
   } catch (error) {
     // Utility graph is optional - don't fail if it can't be loaded
     logError(`[Statement] Could not load utility graph for ${clientId}/${unitId}:`, error.message);

--- a/functions/backend/services/statementDataService.js
+++ b/functions/backend/services/statementDataService.js
@@ -30,10 +30,9 @@ import { isFeatureEnabled } from '../utils/featureFlags.js';
  * @param {string} clientId - Client ID (e.g., 'MTC', 'AVII')
  * @param {string} unitId - Unit ID (e.g., '101', '1A')
  * @param {number} fiscalYearStartMonth - Fiscal year start month (1-12) for month label formatting
- * @param {number|null} fiscalYear - Statement fiscal year (limits water bars to that FY; null = legacy rolling window)
  * @returns {Promise<Object|null>} Utility graph data or null if no data available
  */
-async function getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth = 7, fiscalYear = null) {
+async function getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth = 7) {
   try {
     // Check client config to determine graph type
     const configDoc = await db
@@ -47,7 +46,7 @@ async function getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth = 
     }
     
     // AVII: Water consumption bars
-    return await getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth, fiscalYear);
+    return await getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth);
   } catch (error) {
     logError(`❌ [Utility Graph] Error fetching utility graph data for ${clientId}/${unitId}:`, error);
     return null;
@@ -120,10 +119,9 @@ async function getPropaneGaugeData(db, clientId, unitId, config) {
  * @param {string} clientId - Client ID (should be 'AVII')
  * @param {string} unitId - Unit ID
  * @param {number} fiscalYearStartMonth - Fiscal year start month (1-12) for month label formatting
- * @param {number|null} fiscalYear - Statement fiscal year (filter periods to this FY before taking last 6)
  * @returns {Promise<Object|null>} Water bars data or null
  */
-async function getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth = 7, fiscalYear = null) {
+async function getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth = 7) {
   try {
     // Get all water readings (no orderBy to avoid index requirement)
     // We'll sort in memory to find consecutive months
@@ -199,15 +197,8 @@ async function getWaterBarsData(db, clientId, unitId, fiscalYearStartMonth = 7, 
       priorReading = currentReading;
     }
     
-    // SoA mini-graph: last 6 consumption months within the statement fiscal year (#260).
-    // Reading docs use fiscal `year` + fiscal month index 0–11 (waterReadingsService).
-    // Six bars + dynamic SVG width avoids viewBox clipping when more months were shown.
-    let fyPeriods = periods;
-    if (fiscalYear != null && !Number.isNaN(Number(fiscalYear))) {
-      const fy = Number(fiscalYear);
-      fyPeriods = periods.filter(p => Number(p.year) === fy);
-    }
-    const recentPeriods = fyPeriods.slice(-6);
+    // SoA mini-graph: fixed trailing window — prior 6 consumption periods (rolling, not FY-scoped).
+    const recentPeriods = periods.slice(-6);
     if (recentPeriods.length === 0) {
       return null;
     }
@@ -2913,8 +2904,7 @@ export async function getStatementData(api, clientId, unitId, fiscalYear = null,
     const db = await getDb();
     // Pass fiscal year start month for proper month label formatting
     const fiscalYearStartMonth = rawData.clientConfig?.fiscalYearStartMonth || 7; // Default to July for AVII
-    const statementFiscalYear = rawData.clientConfig?.fiscalYear ?? null;
-    utilityGraph = await getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth, statementFiscalYear);
+    utilityGraph = await getUtilityGraphData(db, clientId, unitId, fiscalYearStartMonth);
   } catch (error) {
     // Utility graph is optional - don't fail if it can't be loaded
     logError(`[Statement] Could not load utility graph for ${clientId}/${unitId}:`, error.message);

--- a/functions/backend/services/statementHtmlService.js
+++ b/functions/backend/services/statementHtmlService.js
@@ -580,30 +580,39 @@ function generateWaterBarsSvg(periods, language) {
   if (maxConsumption === 0) {
     return '';
   }
-  
-  // Increased dimensions for better space utilization (~10% larger, ~385x193)
-  const svgWidth = 385;
-  const svgHeight = 190;
-  const maxHeight = 110;
-  const barWidth = 38;
-  const barSpacing = 9;
-  const startX = 50; // Moved right to make room for Y-axis
-  const baselineY = 140;
+
+  const n = periods.length;
+  // Dynamic width so N bars + gaps never exceed chartRightX (fixes clipping when N=8).
+  const marginLeft = 50;
+  const marginRight = 16;
+  const gap = 8;
+  const minBarWidth = 14;
+  const maxBarWidth = 38;
+  const baselineY = 138;
   const titleY = 20;
-  const labelY = 162;
-  const footerY = 182;
-  const yAxisX = 45; // X position for Y-axis
-  const chartRightX = svgWidth - 35; // Right edge of chart area
-  
+  const labelY = 165;
+  const footerY = 184;
+  const svgHeight = 196;
+  const maxHeight = 105;
+  const innerBudget = 385 - marginLeft - marginRight;
+  let barWidth =
+    n > 0 ? Math.floor((innerBudget - Math.max(0, n - 1) * gap) / n) : maxBarWidth;
+  barWidth = Math.max(minBarWidth, Math.min(maxBarWidth, barWidth));
+  const chartWidth = n * barWidth + Math.max(0, n - 1) * gap;
+  const svgWidth = Math.max(300, marginLeft + chartWidth + marginRight);
+  const startX = marginLeft;
+  const chartRightX = startX + chartWidth;
+  const yAxisX = marginLeft - 5;
+
   // Get fiscal year start month from first period (passed from data service)
   const fiscalYearStartMonth = periods[0]?.fiscalYearStartMonth || 7;
-  
+
   const bars = periods.map((p, i) => {
     const height = Math.round((p.consumption / maxConsumption) * maxHeight) || 2;
-    const x = startX + i * (barWidth + barSpacing);
+    const x = startX + i * (barWidth + gap);
     const y = baselineY - height;
     const label = formatPeriodLabel(p.year, p.month, fiscalYearStartMonth);
-    
+
     return { x, y, height, label, consumption: p.consumption };
   });
   
@@ -1290,6 +1299,7 @@ function buildHtmlContent(data, reportCommonCss, language, t, clientId, unitId, 
     /* Allocation summary table */
     .allocation-graph-row {
       display: flex;
+      flex-wrap: wrap;
       gap: 20px;
       margin: 20px 0;
       align-items: flex-start;
@@ -1314,15 +1324,17 @@ function buildHtmlContent(data, reportCommonCss, language, t, clientId, unitId, 
     }
     
     .mini-graph-container {
-      flex: 0 0 auto;
+      flex: 0 1 auto;
       padding: 0;
       background: transparent;
       border: none;
       display: flex;
       justify-content: center;
       align-items: flex-start;
-      min-width: 385px;
-      max-width: 410px;
+      min-width: 0;
+      max-width: 100%;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
       margin-top: -5px;
     }
     

--- a/functions/backend/services/statementHtmlService.js
+++ b/functions/backend/services/statementHtmlService.js
@@ -571,12 +571,15 @@ function formatPeriodLabel(year, month, fiscalYearStartMonth = 7) {
 function generateWaterBarsSvg(periods, language) {
   const title = language === 'spanish' ? 'CONSUMO DE AGUA' : 'WATER CONSUMPTION';
   const latestLabel = language === 'spanish' ? 'Último' : 'Latest';
-  
-  if (!periods || periods.length === 0) {
+
+  // Never plot more than six bars (fixed SVG); prior months = trailing six only.
+  const plotPeriods = Array.isArray(periods) ? periods.slice(-6) : [];
+
+  if (plotPeriods.length === 0) {
     return '';
   }
-  
-  const maxConsumption = Math.max(...periods.map(p => p.consumption || 0));
+
+  const maxConsumption = Math.max(...plotPeriods.map(p => p.consumption || 0));
   if (maxConsumption === 0) {
     return '';
   }
@@ -595,9 +598,9 @@ function generateWaterBarsSvg(periods, language) {
   const yAxisX = 45;
   const chartRightX = svgWidth - 35;
 
-  const fiscalYearStartMonth = periods[0]?.fiscalYearStartMonth || 7;
+  const fiscalYearStartMonth = plotPeriods[0]?.fiscalYearStartMonth || 7;
 
-  const bars = periods.map((p, i) => {
+  const bars = plotPeriods.map((p, i) => {
     const height = Math.round((p.consumption / maxConsumption) * maxHeight) || 2;
     const x = startX + i * (barWidth + barSpacing);
     const y = baselineY - height;
@@ -614,7 +617,7 @@ function generateWaterBarsSvg(periods, language) {
     `<text x="${b.x + barWidth/2}" y="${labelY}" text-anchor="middle" font-size="10" fill="#666">${b.label}</text>`
   ).join('\n      ');
   
-  const latest = periods[periods.length - 1];
+  const latest = plotPeriods[plotPeriods.length - 1];
   
   return `
     <svg viewBox="0 0 ${svgWidth} ${svgHeight}" width="${svgWidth}" height="${svgHeight}" xmlns="http://www.w3.org/2000/svg">

--- a/functions/backend/services/statementHtmlService.js
+++ b/functions/backend/services/statementHtmlService.js
@@ -563,7 +563,7 @@ function formatPeriodLabel(year, month, fiscalYearStartMonth = 7) {
 }
 
 /**
- * Generate water consumption bar chart SVG
+ * Generate water consumption bar chart SVG (fixed 385×190, six bar slots — expect ≤6 periods from data service).
  * @param {Array} periods - Array of { year, month, consumption } objects
  * @param {string} language - Language ('english' or 'spanish')
  * @returns {string} SVG markup
@@ -581,35 +581,25 @@ function generateWaterBarsSvg(periods, language) {
     return '';
   }
 
-  const n = periods.length;
-  // Dynamic width so N bars + gaps never exceed chartRightX (fixes clipping when N=8).
-  const marginLeft = 50;
-  const marginRight = 16;
-  const gap = 8;
-  const minBarWidth = 14;
-  const maxBarWidth = 38;
-  const baselineY = 138;
+  // Fixed layout: SoA water mini-graph always uses six bar slots (data layer sends at most 6 periods).
+  const svgWidth = 385;
+  const svgHeight = 190;
+  const maxHeight = 110;
+  const barWidth = 38;
+  const barSpacing = 9;
+  const startX = 50;
+  const baselineY = 140;
   const titleY = 20;
-  const labelY = 165;
-  const footerY = 184;
-  const svgHeight = 196;
-  const maxHeight = 105;
-  const innerBudget = 385 - marginLeft - marginRight;
-  let barWidth =
-    n > 0 ? Math.floor((innerBudget - Math.max(0, n - 1) * gap) / n) : maxBarWidth;
-  barWidth = Math.max(minBarWidth, Math.min(maxBarWidth, barWidth));
-  const chartWidth = n * barWidth + Math.max(0, n - 1) * gap;
-  const svgWidth = Math.max(300, marginLeft + chartWidth + marginRight);
-  const startX = marginLeft;
-  const chartRightX = startX + chartWidth;
-  const yAxisX = marginLeft - 5;
+  const labelY = 162;
+  const footerY = 182;
+  const yAxisX = 45;
+  const chartRightX = svgWidth - 35;
 
-  // Get fiscal year start month from first period (passed from data service)
   const fiscalYearStartMonth = periods[0]?.fiscalYearStartMonth || 7;
 
   const bars = periods.map((p, i) => {
     const height = Math.round((p.consumption / maxConsumption) * maxHeight) || 2;
-    const x = startX + i * (barWidth + gap);
+    const x = startX + i * (barWidth + barSpacing);
     const y = baselineY - height;
     const label = formatPeriodLabel(p.year, p.month, fiscalYearStartMonth);
 
@@ -1299,7 +1289,6 @@ function buildHtmlContent(data, reportCommonCss, language, t, clientId, unitId, 
     /* Allocation summary table */
     .allocation-graph-row {
       display: flex;
-      flex-wrap: wrap;
       gap: 20px;
       margin: 20px 0;
       align-items: flex-start;
@@ -1324,17 +1313,15 @@ function buildHtmlContent(data, reportCommonCss, language, t, clientId, unitId, 
     }
     
     .mini-graph-container {
-      flex: 0 1 auto;
+      flex: 0 0 auto;
       padding: 0;
       background: transparent;
       border: none;
       display: flex;
       justify-content: center;
       align-items: flex-start;
-      min-width: 0;
-      max-width: 100%;
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
+      min-width: 385px;
+      max-width: 410px;
       margin-top: -5px;
     }
     


### PR DESCRIPTION
## Problem
Water mini-graph could show **more than six** consumption periods (previously up to eight), while the SVG was sized for fewer bars — bars and labels overflowed / looked like the chart scrolled off the report.

## Fix
- **Data:** `getWaterBarsData` returns only the **rolling prior six** consumption periods: `periods.slice(-6)` after the reading walk.
- **SVG:** Fixed **385×190** layout with six bar slots (38px bars, 9px spacing). `generateWaterBarsSvg` also applies **defensive** `periods.slice(-6)` so the chart never draws more than six bars even if the payload regressed.
- **CSS:** `.mini-graph-container` fixed width band (385–410px) aligned to the SVG.

## Out of scope / not in PR
- Version bump files are not part of this change.

## Testing
Manual SoA check: six months visible (e.g. Oct–Mar), no clipping, **Latest** line matches rightmost bar.

Closes #260