### PR TITLE
fix(bugsweep): unify cross-client owner/manager assignment for #246 and #231

### DIFF
--- a/frontend/sams-ui/src/api/user.js
+++ b/frontend/sams-ui/src/api/user.js
@@ -102,6 +102,25 @@ export const userAPI = {
   },
 
   /**
+   * Full directory list (same as UserPicker / secureApi getSystemUsers).
+   * No clientId query — backend returns users visible to the caller (e.g. SuperAdmin: all; admin: shared-client overlap).
+   */
+  async getSystemUsers() {
+    try {
+      const headers = await getAuthHeaders();
+      const response = await fetch(`${API_BASE_URL}/admin/users`, {
+        method: 'GET',
+        headers
+      });
+      const result = await handleApiResponse(response);
+      return result.users || [];
+    } catch (error) {
+      console.error('Failed to fetch system users:', error);
+      throw new Error(`Failed to load users: ${error.message}`);
+    }
+  },
+
+  /**
    * Update user propertyAccess for a specific client
    * @param {string} userId - The user ID to update
    * @param {string} clientId - The client ID

--- a/frontend/sams-ui/src/components/common/UserPicker.jsx
+++ b/frontend/sams-ui/src/components/common/UserPicker.jsx
@@ -9,7 +9,7 @@ import { useSecureApi } from '../../api/secureApiClient.js';
  * @param {string} clientId - The client ID to filter users by
  * @param {string} selectedUserId - Currently selected user ID (or null)
  * @param {Function} onSelect - Callback when user is selected (userId) => void
- * @param {Array<string>} allowedRoles - Optional array of roles to filter by (e.g., ['unitOwner', 'unitManager'])
+ * @param {Array<string>} allowedRoles - Optional: filter by propertyAccess[clientId].role. Only applied when restrictToUsersWithClientAccess is true; ignored in cross-client mode (those users have no role on this client yet).
  * @param {string} label - Label for the picker
  * @param {boolean} required - Whether selection is required
  * @param {boolean} restrictToUsersWithClientAccess - When true (default), only users with propertyAccess[clientId] appear. Set false for unit owner/manager assignment so cross-client users can be selected.
@@ -55,8 +55,8 @@ const UserPicker = ({
           console.log(`📊 UserPicker: showing all ${filtered.length} users (cross-client assignment mode for ${clientId})`);
         }
         
-        // Filter by roles if specified
-        if (allowedRoles && allowedRoles.length > 0) {
+        // Filter by roles on this client (requires propertyAccess[clientId]; skip when listing cross-client assignees)
+        if (allowedRoles && allowedRoles.length > 0 && restrictToUsersWithClientAccess) {
           filtered = filtered.filter(user => {
             const access = user.propertyAccess?.[clientId];
             if (!access) {

--- a/frontend/sams-ui/src/components/common/UserPicker.jsx
+++ b/frontend/sams-ui/src/components/common/UserPicker.jsx
@@ -12,6 +12,7 @@ import { useSecureApi } from '../../api/secureApiClient.js';
  * @param {Array<string>} allowedRoles - Optional array of roles to filter by (e.g., ['unitOwner', 'unitManager'])
  * @param {string} label - Label for the picker
  * @param {boolean} required - Whether selection is required
+ * @param {boolean} restrictToUsersWithClientAccess - When true (default), only users with propertyAccess[clientId] appear. Set false for unit owner/manager assignment so cross-client users can be selected.
  */
 const UserPicker = ({ 
   clientId, 
@@ -19,7 +20,8 @@ const UserPicker = ({
   onSelect, 
   allowedRoles = null, 
   label = 'User',
-  required = false 
+  required = false,
+  restrictToUsersWithClientAccess = true
 }) => {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -38,9 +40,9 @@ const UserPicker = ({
         
         console.log(`🔍 UserPicker: Fetched ${allUsers.length} total users`);
         
-        // Filter by clientId if provided
+        // Filter by clientId if provided (optional: unit assignment lists all assignable users)
         let filtered = allUsers;
-        if (clientId) {
+        if (clientId && restrictToUsersWithClientAccess) {
           filtered = allUsers.filter(user => {
             const hasAccess = user.propertyAccess?.[clientId] != null;
             if (!hasAccess && user.email) {
@@ -49,6 +51,8 @@ const UserPicker = ({
             return hasAccess;
           });
           console.log(`📊 UserPicker: ${filtered.length} users have access to clientId: ${clientId}`);
+        } else if (clientId && !restrictToUsersWithClientAccess) {
+          console.log(`📊 UserPicker: showing all ${filtered.length} users (cross-client assignment mode for ${clientId})`);
         }
         
         // Filter by roles if specified
@@ -84,7 +88,7 @@ const UserPicker = ({
     };
 
     fetchUsers();
-  }, [clientId, allowedRoles, secureApi]);
+  }, [clientId, allowedRoles, restrictToUsersWithClientAccess, secureApi]);
 
   if (loading) {
     return (
@@ -116,7 +120,9 @@ const UserPicker = ({
           <option>No users available for this client</option>
         </select>
         <span className="sandyland-helper-text">
-          No users found. Create users in User Management first.
+          {restrictToUsersWithClientAccess
+            ? 'No users found. Create users in User Management first.'
+            : 'No users returned from directory. Create users in User Management first.'}
         </span>
       </div>
     );

--- a/frontend/sams-ui/src/components/modals/UnitFormModal.jsx
+++ b/frontend/sams-ui/src/components/modals/UnitFormModal.jsx
@@ -584,6 +584,7 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
                           allowedRoles={null}
                           label="Owner"
                           required={index === 0}
+                          restrictToUsersWithClientAccess={false}
                         />
                       </div>
                       <button
@@ -626,6 +627,7 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
                               allowedRoles={null}
                               label="Manager"
                               required={false}
+                              restrictToUsersWithClientAccess={false}
                             />
                           </div>
                           <button

--- a/frontend/sams-ui/src/components/modals/UnitFormModal.jsx
+++ b/frontend/sams-ui/src/components/modals/UnitFormModal.jsx
@@ -326,6 +326,22 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
     return Object.keys(newErrors).length === 0;
   };
 
+  /** Resolve display fields after UserPicker selection (cross-client users are not in getUsersByClient). */
+  const resolveUserFromDirectory = async (userId) => {
+    if (!userId) return null;
+    if (selectedClient?.id) {
+      try {
+        const clientUsers = await userAPI.getUsersByClient(selectedClient.id);
+        const match = clientUsers.find((u) => u.id === userId);
+        if (match) return match;
+      } catch (e) {
+        console.warn('resolveUserFromDirectory: client list failed, falling back to system users', e);
+      }
+    }
+    const allUsers = await userAPI.getSystemUsers();
+    return allUsers.find((u) => u.id === userId) || null;
+  };
+
   // Helper functions for managing owners/managers arrays
   const updateOwner = (index, field, value) => {
     const newOwners = [...formData.owners];
@@ -336,24 +352,20 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
   const updateOwnerUser = async (index, userId) => {
     const newOwners = [...formData.owners];
     if (userId) {
-      // When a user is selected, fetch user data and populate name/email
       try {
-        const users = await userAPI.getUsersByClient(selectedClient.id);
-        const selectedUser = users.find(u => u.id === userId);
+        const selectedUser = await resolveUserFromDirectory(userId);
         if (selectedUser) {
           newOwners[index] = {
             name: selectedUser.name || selectedUser.displayName || selectedUser.email || '',
             email: selectedUser.email || '',
-            userId: userId
+            userId
           };
         } else {
-          // User not found, just set userId
-          newOwners[index] = { ...newOwners[index], userId: userId };
+          newOwners[index] = { ...newOwners[index], userId };
         }
       } catch (error) {
         console.error('Error fetching user data:', error);
-        // Fallback: just set userId
-        newOwners[index] = { ...newOwners[index], userId: userId };
+        newOwners[index] = { ...newOwners[index], userId };
       }
     } else {
       // Clearing selection - keep name/email but clear userId
@@ -387,24 +399,20 @@ const UnitFormModal = ({ unit = null, isOpen, onClose, onSave }) => {
   const updateManagerUser = async (index, userId) => {
     const newManagers = [...formData.managers];
     if (userId) {
-      // When a user is selected, fetch user data and populate name/email
       try {
-        const users = await userAPI.getUsersByClient(selectedClient.id);
-        const selectedUser = users.find(u => u.id === userId);
+        const selectedUser = await resolveUserFromDirectory(userId);
         if (selectedUser) {
           newManagers[index] = {
             name: selectedUser.name || selectedUser.displayName || selectedUser.email || '',
             email: selectedUser.email || '',
-            userId: userId
+            userId
           };
         } else {
-          // User not found, just set userId
-          newManagers[index] = { ...newManagers[index], userId: userId };
+          newManagers[index] = { ...newManagers[index], userId };
         }
       } catch (error) {
         console.error('Error fetching user data:', error);
-        // Fallback: just set userId
-        newManagers[index] = { ...newManagers[index], userId: userId };
+        newManagers[index] = { ...newManagers[index], userId };
       }
     } else {
       // Clearing selection - keep name/email but clear userId

--- a/functions/backend/controllers/userManagementController.js
+++ b/functions/backend/controllers/userManagementController.js
@@ -1194,21 +1194,24 @@ export async function updateUserPropertyAccess(req, res) {
     const currentPropertyAccess = userData.propertyAccess || {};
     const currentClientAccess = currentPropertyAccess[clientId] || {};
     
-    // Build update data
+    const roleField = `propertyAccess.${clientId}.role`;
+    const unitIdField = `propertyAccess.${clientId}.unitId`;
+
+    // Build update data (use `in` so explicit null clears unitId instead of being treated as falsy)
     const updateData = {};
     if (role !== undefined) {
-      updateData[`propertyAccess.${clientId}.role`] = role;
+      updateData[roleField] = role;
     }
     if (unitId !== undefined) {
-      updateData[`propertyAccess.${clientId}.unitId`] = unitId;
+      updateData[unitIdField] = unitId;
     }
     
-    // Preserve other fields in propertyAccess[clientId]
-    if (!updateData[`propertyAccess.${clientId}.role`] && currentClientAccess.role) {
-      updateData[`propertyAccess.${clientId}.role`] = currentClientAccess.role;
+    // Preserve other fields in propertyAccess[clientId] only when not explicitly set in this request
+    if (!(roleField in updateData) && currentClientAccess.role) {
+      updateData[roleField] = currentClientAccess.role;
     }
-    if (!updateData[`propertyAccess.${clientId}.unitId`] && currentClientAccess.unitId) {
-      updateData[`propertyAccess.${clientId}.unitId`] = currentClientAccess.unitId;
+    if (!(unitIdField in updateData) && currentClientAccess.unitId) {
+      updateData[unitIdField] = currentClientAccess.unitId;
     }
     if (currentClientAccess.permissions) {
       updateData[`propertyAccess.${clientId}.permissions`] = currentClientAccess.permissions;

--- a/functions/backend/middleware/unitAuthorization.js
+++ b/functions/backend/middleware/unitAuthorization.js
@@ -50,6 +50,11 @@ const requireUnitAccess = (req, res, next) => {
     || req.user.samsProfile?.clientAccess?.[clientId];
   const userGlobalRole = req.user.samsProfile?.globalRole; // CRITICAL: Include global role
 
+  // Align with hasUnitAccess: global admin/superAdmin may access any unit without per-client map
+  if (['admin', 'superAdmin'].includes(userGlobalRole)) {
+    return next();
+  }
+
   if (!propertyAccess) {
     return res.status(403).json({
       error: 'Access denied to this client',

--- a/functions/backend/middleware/unitAuthorization.js
+++ b/functions/backend/middleware/unitAuthorization.js
@@ -18,12 +18,15 @@ const hasUnitAccess = (propertyAccess, requestedUnitId, userGlobalRole = null) =
     return true;
   }
   
-  // Direct unit ownership
-  if (propertyAccess.role === 'unitOwner' && propertyAccess.unitId === requestedUnitId) {
+  // Primary unit on client (legacy shape from PATCH / propertyAccess sync — owners and managers)
+  if (
+    (propertyAccess.role === 'unitOwner' || propertyAccess.role === 'unitManager') &&
+    propertyAccess.unitId === requestedUnitId
+  ) {
     return true;
   }
   
-  // Unit management assignments (NEW LOGIC)
+  // Unit management assignments (multi-unit / explicit array)
   if (propertyAccess.unitAssignments && Array.isArray(propertyAccess.unitAssignments)) {
     return propertyAccess.unitAssignments.some(assignment => 
       assignment.unitId === requestedUnitId && 
@@ -43,8 +46,17 @@ const hasUnitAccess = (propertyAccess, requestedUnitId, userGlobalRole = null) =
 const requireUnitAccess = (req, res, next) => {
   const { unitId } = req.params;
   const clientId = req.originalParams?.clientId || req.params.clientId;
-  const propertyAccess = req.user.propertyAccess[clientId];
+  const propertyAccess = req.user.samsProfile?.propertyAccess?.[clientId]
+    || req.user.samsProfile?.clientAccess?.[clientId];
   const userGlobalRole = req.user.samsProfile?.globalRole; // CRITICAL: Include global role
+
+  if (!propertyAccess) {
+    return res.status(403).json({
+      error: 'Access denied to this client',
+      clientId,
+      code: 'CLIENT_ACCESS_DENIED'
+    });
+  }
   
   if (!hasUnitAccess(propertyAccess, unitId, userGlobalRole)) {
     return res.status(403).json({ 

--- a/functions/backend/testing/verify-cross-client-unit-access.mjs
+++ b/functions/backend/testing/verify-cross-client-unit-access.mjs
@@ -1,0 +1,24 @@
+/**
+ * Quick regression check for BUGSWEEP-231: legacy propertyAccess.unitId + unitManager
+ * must authorize the same unit (mirrors unitOwner). Run: node testing/verify-cross-client-unit-access.mjs
+ */
+import { hasUnitAccess } from '../middleware/unitAuthorization.js';
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error('FAIL:', msg);
+    process.exit(1);
+  }
+}
+
+const mgr = { role: 'unitManager', unitId: '101' };
+assert(hasUnitAccess(mgr, '101', 'user') === true, 'unitManager + matching unitId should allow');
+assert(hasUnitAccess(mgr, '202', 'user') === false, 'unitManager + other unit should deny');
+
+const owner = { role: 'unitOwner', unitId: '101' };
+assert(hasUnitAccess(owner, '101', 'user') === true, 'unitOwner + matching unitId should allow');
+
+const mgrViaAssignments = { role: 'unitManager', unitAssignments: [{ unitId: '303', role: 'unitManager' }] };
+assert(hasUnitAccess(mgrViaAssignments, '303', 'user') === true, 'unitAssignments path for manager');
+
+console.log('OK: verify-cross-client-unit-access checks passed');


### PR DESCRIPTION
## Issues
- Closes #246 — Unit edit owner/manager picker restricted to users who already had `propertyAccess` for the client.
- Closes #231 — Cross-client unit assignment: `unitManager` with legacy `propertyAccess[client].unitId` was not honored by `hasUnitAccess` (only `unitOwner` matched). PATCH property-access could also fail to clear `unitId` when sending `null` (falsy preserve logic).

## What changed

### #246
- `UserPicker`: new prop `restrictToUsersWithClientAccess` (default `true` for existing behavior).
- `UnitFormModal`: owner and manager pickers set `restrictToUsersWithClientAccess={false}` so any directory user can be selected; existing save flow still calls `userAPI.updateUserPropertyAccess` for new/changed assignments.

### #231
- `hasUnitAccess`: treat legacy `unitManager` + matching `unitId` like `unitOwner`.
- `updateUserPropertyAccess`: preserve `role`/`unitId` only when those fields were not present in the PATCH body (`in` operator), so explicit `unitId: null` clears correctly.
- `requireUnitAccess`: read access from `req.user.samsProfile` (was `req.user.propertyAccess`, which is never set by `authenticateUserWithProfile`).

## Why one PR
Both issues share the unit-assignment / `propertyAccess` surface area; frontend picker change is independent but required for the same admin workflow.

## Downstream impact
- List Management → Units → Edit Unit (owner/manager pickers).
- User Management unchanged (still uses admin user list APIs).
- Auth: `hasPropertyAccess` unchanged; unit-scoped routes using `hasUnitAccess` gain correct manager behavior.
- `requireUnitAccess` is not referenced by routes today; fix is defensive.

## Test evidence
| Check | Result |
|-------|--------|
| `node functions/backend/testing/verify-cross-client-unit-access.mjs` | Pass |
| `bash scripts/pre-pr-checks.sh main` | Pass |

Live API test harness with tokens was not run in this agent environment; recommend a quick PATCH `/admin/users/:uid/property-access/:clientId` + unit-scoped GET smoke test in your usual harness.

## BugBot
Please run BugBot on this PR; follow-up commits as needed.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unit authorization and user `propertyAccess` patch semantics; mistakes could incorrectly grant/deny unit access or fail to clear assignments, though changes are scoped and include a regression script.
> 
> **Overview**
> Fixes cross-client unit owner/manager assignment and authorization edge cases across frontend and backend.
> 
> On the frontend, `UserPicker` gains `restrictToUsersWithClientAccess` (defaulting to current behavior) and `UnitFormModal` uses cross-client mode for owner/manager selection, adding a directory lookup fallback (`getSystemUsers`) to populate name/email for selected users outside the client.
> 
> On the backend, `updateUserPropertyAccess` now preserves existing `role`/`unitId` only when the field was not sent (so `unitId: null` reliably clears), `hasUnitAccess` treats legacy `unitManager`+`unitId` like `unitOwner`, and `requireUnitAccess` reads access from `req.user.samsProfile` with an admin/superAdmin bypass. Adds `testing/verify-cross-client-unit-access.mjs` as a quick regression check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a128034a57629270c801b0f9faf80e9455517bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->