### PR TITLE
fix(mobile): unify SoA entry paths and labels for #251

### DIFF
--- a/frontend/mobile-app/src/App.jsx
+++ b/frontend/mobile-app/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { AuthProvider, useAuth } from './hooks/useAuthStable.jsx';
+import { SessionPreferencesProvider } from './context/SessionPreferencesContext.jsx';
 import { SelectedUnitProvider } from './context/SelectedUnitContext.jsx';
 import { UnitStatementProvider } from './context/UnitStatementContext.jsx';
 import AuthScreen from './components/AuthScreen';
@@ -114,6 +115,7 @@ function App() {
       <CssBaseline />
       <AuthProvider>
         <Router>
+          <SessionPreferencesProvider>
           <SelectedUnitProvider>
           <UnitStatementProvider>
           <Layout>
@@ -387,6 +389,7 @@ function App() {
           </Layout>
           </UnitStatementProvider>
           </SelectedUnitProvider>
+          </SessionPreferencesProvider>
         </Router>
       </AuthProvider>
     </ThemeProvider>

--- a/frontend/mobile-app/src/components/Layout.jsx
+++ b/frontend/mobile-app/src/components/Layout.jsx
@@ -16,6 +16,8 @@ import {
   Select,
   MenuItem,
   FormControl,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import {
   ArrowBack,
@@ -36,6 +38,7 @@ import {
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuthStable.jsx';
+import { useSessionPreferences } from '../context/SessionPreferencesContext.jsx';
 import { useSelectedUnit } from '../context/SelectedUnitContext.jsx';
 import PWANavigation from './PWANavigation.jsx';
 import UserProfileManager from './UserProfileManager.jsx';
@@ -50,6 +53,7 @@ const Layout = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, logout, isAdmin, samsUser, currentClient } = useAuth();
+  const { preferredLanguageUi, setPreferredLanguageUi } = useSessionPreferences();
   const { selectedUnitId, setSelectedUnitId, availableUnits } = useSelectedUnit();
 
   const isOwnerOrManager = checkIsOwnerOrManager(samsUser);
@@ -252,6 +256,29 @@ const Layout = ({ children }) => {
           <Typography variant="h6" sx={{ fontWeight: 600 }}>SAMS Mobile</Typography>
         </Box>
         <Divider />
+
+        {user && (
+          <>
+            <Box sx={{ px: 2, py: 1.5 }}>
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+                Language / Idioma
+              </Typography>
+              <ToggleButtonGroup
+                exclusive
+                size="small"
+                fullWidth
+                value={preferredLanguageUi}
+                onChange={(_, v) => {
+                  if (v) setPreferredLanguageUi(v);
+                }}
+              >
+                <ToggleButton value="EN" sx={{ textTransform: 'none' }}>English</ToggleButton>
+                <ToggleButton value="ES" sx={{ textTransform: 'none' }}>Español</ToggleButton>
+              </ToggleButtonGroup>
+            </Box>
+            <Divider />
+          </>
+        )}
 
         {/* Unit selector for non-admin-shell users */}
         {!showAdminShell && availableUnits.length > 0 && (

--- a/frontend/mobile-app/src/components/Layout.jsx
+++ b/frontend/mobile-app/src/components/Layout.jsx
@@ -341,7 +341,7 @@ const Layout = ({ children }) => {
                         sx={{ fontSize: '1.7rem', lineHeight: 1, display: 'inline-flex' }}
                         aria-hidden
                       >
-                        {preferredLanguageUi === 'ES' ? '🇺🇸' : '🇲🇽'}
+                        {preferredLanguageUi === 'ES' ? '🇲🇽' : '🇺🇸'}
                       </Box>
                     </Box>
                   }

--- a/frontend/mobile-app/src/components/Layout.jsx
+++ b/frontend/mobile-app/src/components/Layout.jsx
@@ -330,8 +330,21 @@ const Layout = ({ children }) => {
                   <PublicIcon />
                 </ListItemIcon>
                 <ListItemText
-                  primary={preferredLanguageUi === 'ES' ? '🌐 Idioma: 🇺🇸' : '🌐 Language: 🇲🇽'}
-                  primaryTypographyProps={{ sx: { fontSize: '0.95rem' } }}
+                  disableTypography
+                  primary={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'nowrap' }}>
+                      <Typography component="span" variant="body2" sx={{ fontSize: '0.95rem' }}>
+                        {preferredLanguageUi === 'ES' ? 'Idioma:' : 'Language:'}
+                      </Typography>
+                      <Box
+                        component="span"
+                        sx={{ fontSize: '1.7rem', lineHeight: 1, display: 'inline-flex' }}
+                        aria-hidden
+                      >
+                        {preferredLanguageUi === 'ES' ? '🇺🇸' : '🇲🇽'}
+                      </Box>
+                    </Box>
+                  }
                 />
               </ListItemButton>
             </ListItem>

--- a/frontend/mobile-app/src/components/Layout.jsx
+++ b/frontend/mobile-app/src/components/Layout.jsx
@@ -16,8 +16,6 @@ import {
   Select,
   MenuItem,
   FormControl,
-  ToggleButton,
-  ToggleButtonGroup,
 } from '@mui/material';
 import {
   ArrowBack,
@@ -35,6 +33,7 @@ import {
   DownloadForOffline as InstallIcon,
   Contacts as ContactsIcon,
   CurrencyExchange as ExchangeRatesIcon,
+  Public as PublicIcon,
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuthStable.jsx';
@@ -257,29 +256,6 @@ const Layout = ({ children }) => {
         </Box>
         <Divider />
 
-        {user && (
-          <>
-            <Box sx={{ px: 2, py: 1.5 }}>
-              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
-                Language / Idioma
-              </Typography>
-              <ToggleButtonGroup
-                exclusive
-                size="small"
-                fullWidth
-                value={preferredLanguageUi}
-                onChange={(_, v) => {
-                  if (v) setPreferredLanguageUi(v);
-                }}
-              >
-                <ToggleButton value="EN" sx={{ textTransform: 'none' }}>English</ToggleButton>
-                <ToggleButton value="ES" sx={{ textTransform: 'none' }}>Español</ToggleButton>
-              </ToggleButtonGroup>
-            </Box>
-            <Divider />
-          </>
-        )}
-
         {/* Unit selector for non-admin-shell users */}
         {!showAdminShell && availableUnits.length > 0 && (
           <>
@@ -341,6 +317,25 @@ const Layout = ({ children }) => {
               </ListItemButton>
             </ListItem>
           ))}
+          {user && (
+            <ListItem disablePadding>
+              <ListItemButton
+                onClick={() => {
+                  setPreferredLanguageUi((prev) => (prev === 'ES' ? 'EN' : 'ES'));
+                  setDrawerOpen(false);
+                }}
+                sx={{ minHeight: 48 }}
+              >
+                <ListItemIcon sx={{ minWidth: 40 }}>
+                  <PublicIcon />
+                </ListItemIcon>
+                <ListItemText
+                  primary={preferredLanguageUi === 'ES' ? '🌐 Idioma: 🇺🇸' : '🌐 Language: 🇲🇽'}
+                  primaryTypographyProps={{ sx: { fontSize: '0.95rem' } }}
+                />
+              </ListItemButton>
+            </ListItem>
+          )}
           {!isInstalled && isMobile && (
             <ListItem disablePadding>
               <ListItemButton

--- a/frontend/mobile-app/src/components/owner/MoreMenu.jsx
+++ b/frontend/mobile-app/src/components/owner/MoreMenu.jsx
@@ -1,12 +1,11 @@
 /**
  * More Menu — Secondary screens for mobile owners
- * Links: Statement of Account, Exchange Rate Calculator, About, Install App
- * Sprint MOBILE-OWNER-UX (MOB-5)
+ * Statement of Account lives on My Unit + /statement (issue #251); not duplicated here.
+ * Links: Exchange Rate Calculator, About, Install App
  */
 import React from 'react';
 import { Box, Typography, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import {
-  PictureAsPdf as StatementIcon,
   CurrencyExchange as ExchangeIcon,
   Info as AboutIcon,
   DownloadForOffline as InstallIcon,
@@ -19,7 +18,6 @@ const MoreMenu = () => {
   const { isInstalled, isMobile, reopenInstallUI } = useInstallPrompt();
 
   const items = [
-    { label: 'Statement of Account', icon: <StatementIcon />, path: '/statement' },
     { label: 'Exchange Rate Calculator', icon: <ExchangeIcon />, path: '/exchange-rates' },
     { label: 'About', icon: <AboutIcon />, path: '/about' },
   ];

--- a/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
+++ b/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
@@ -4,8 +4,6 @@ import {
   Typography,
   Alert,
   Button,
-  ToggleButton,
-  ToggleButtonGroup,
   Select,
   MenuItem,
   FormControl,
@@ -21,11 +19,15 @@ import {
 import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuthStable.jsx';
+import { useSessionPreferences } from '../../context/SessionPreferencesContext.jsx';
 import { useSelectedUnit } from '../../context/SelectedUnitContext.jsx';
 import { config } from '../../config/index.js';
 import { auth, db } from '../../services/firebase';
 import { LoadingSpinner } from '../common';
-import { buildDedupedStoredStatementsForUi } from '../../utils/storedStatementLabels.js';
+import {
+  buildDedupedStoredStatementsForUi,
+  filterDedupedStatementsByUiLanguage,
+} from '../../utils/storedStatementLabels.js';
 
 const API_BASE_URL = config.api.baseUrl;
 
@@ -33,6 +35,7 @@ const StatementPdfViewer = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { currentClient, firebaseUser } = useAuth();
+  const { statementLanguageApi, preferredLanguageUi } = useSessionPreferences();
   const { selectedUnitId } = useSelectedUnit();
 
   const clientId = typeof currentClient === 'string' ? currentClient : currentClient?.id;
@@ -43,7 +46,6 @@ const StatementPdfViewer = () => {
   const [selectedStored, setSelectedStored] = useState('');
 
   // Generate state
-  const [language, setLanguage] = useState('english');
   const [pdfUrl, setPdfUrl] = useState(null);
   const [pdfSource, setPdfSource] = useState(null); // 'stored' | 'generated'
   const [loading, setLoading] = useState(false);
@@ -103,7 +105,15 @@ const StatementPdfViewer = () => {
     };
   }, [pdfUrl, pdfSource]);
 
-  const storedOptions = buildDedupedStoredStatementsForUi(storedStatements);
+  const storedOptionsAll = buildDedupedStoredStatementsForUi(storedStatements);
+  const storedOptions = filterDedupedStatementsByUiLanguage(storedOptionsAll, preferredLanguageUi);
+
+  useEffect(() => {
+    const allowed = new Set(storedOptions.map((s) => s.id));
+    if (selectedStored && !allowed.has(selectedStored)) {
+      setSelectedStored('');
+    }
+  }, [storedOptions, selectedStored]);
 
   // Deep-link from My Unit (and similar): open stored PDF in-app like this screen's iframe viewer
   useEffect(() => {
@@ -157,7 +167,7 @@ const StatementPdfViewer = () => {
       if (!user) throw new Error('No authenticated user');
 
       const token = await user.getIdToken();
-      const url = `${API_BASE_URL}/reports/${clientId}/statement/pdf?unitId=${selectedUnitId}&language=${language}`;
+      const url = `${API_BASE_URL}/reports/${clientId}/statement/pdf?unitId=${selectedUnitId}&language=${statementLanguageApi}`;
 
       const response = await fetch(url, {
         method: 'GET',
@@ -265,23 +275,16 @@ const StatementPdfViewer = () => {
             </Typography>
           </Box>
 
-          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-            <ToggleButtonGroup
-              value={language}
-              exclusive
-              onChange={(_, val) => { if (val) setLanguage(val); }}
-              size="small"
-            >
-              <ToggleButton value="english" sx={{ textTransform: 'none', px: 1.5 }}>EN</ToggleButton>
-              <ToggleButton value="spanish" sx={{ textTransform: 'none', px: 1.5 }}>ES</ToggleButton>
-            </ToggleButtonGroup>
-
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+            Uses your menu language ({preferredLanguageUi === 'ES' ? 'Español' : 'English'}). Change in the sidebar menu under Language / Idioma.
+          </Typography>
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
             <Button
               variant="contained"
               size="small"
               onClick={handleGenerateCurrent}
               disabled={loading}
-              sx={{ ml: 'auto', textTransform: 'none' }}
+              sx={{ textTransform: 'none' }}
             >
               {loading ? 'Generating...' : 'Generate'}
             </Button>

--- a/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
+++ b/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -17,7 +17,6 @@ import {
   NoteAdd as GenerateIcon,
 } from '@mui/icons-material';
 import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
-import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuthStable.jsx';
 import { useSessionPreferences } from '../../context/SessionPreferencesContext.jsx';
 import { useSelectedUnit } from '../../context/SelectedUnitContext.jsx';
@@ -32,15 +31,13 @@ import {
 const API_BASE_URL = config.api.baseUrl;
 
 const StatementPdfViewer = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
   const { currentClient, firebaseUser } = useAuth();
   const { statementLanguageApi, preferredLanguageUi } = useSessionPreferences();
   const { selectedUnitId } = useSelectedUnit();
 
   const clientId = typeof currentClient === 'string' ? currentClient : currentClient?.id;
 
-  // Stored statements state — start true so deep-link effect does not clear router state before first fetch runs
+  // Stored statements state — start true until first fetch settles (avoids empty flash)
   const [storedStatements, setStoredStatements] = useState([]);
   const [storedLoading, setStoredLoading] = useState(true);
   const [selectedStored, setSelectedStored] = useState('');
@@ -50,11 +47,6 @@ const StatementPdfViewer = () => {
   const [pdfSource, setPdfSource] = useState(null); // 'stored' | 'generated'
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-
-  const pdfSourceRef = useRef(pdfSource);
-  const pdfUrlRef = useRef(pdfUrl);
-  pdfSourceRef.current = pdfSource;
-  pdfUrlRef.current = pdfUrl;
 
   // Fetch stored statement metadata from Firestore
   const fetchStoredStatements = useCallback(async () => {
@@ -109,8 +101,14 @@ const StatementPdfViewer = () => {
     };
   }, [pdfUrl, pdfSource]);
 
-  const storedOptionsAll = buildDedupedStoredStatementsForUi(storedStatements);
-  const storedOptions = filterDedupedStatementsByUiLanguage(storedOptionsAll, preferredLanguageUi);
+  const storedOptionsAll = useMemo(
+    () => buildDedupedStoredStatementsForUi(storedStatements),
+    [storedStatements],
+  );
+  const storedOptions = useMemo(
+    () => filterDedupedStatementsByUiLanguage(storedOptionsAll, preferredLanguageUi),
+    [storedOptionsAll, preferredLanguageUi],
+  );
 
   useEffect(() => {
     const allowed = new Set(storedOptions.map((s) => s.id));
@@ -118,31 +116,6 @@ const StatementPdfViewer = () => {
       setSelectedStored('');
     }
   }, [storedOptions, selectedStored]);
-
-  // Deep-link from My Unit (and similar): open stored PDF in-app like this screen's iframe viewer
-  useEffect(() => {
-    const openId = location.state?.openStoredStatementId;
-    if (!openId || storedLoading) return;
-
-    if (!storedStatements.length) {
-      navigate(location.pathname, { replace: true, state: {} });
-      return;
-    }
-
-    const statement = storedStatements.find((s) => s.id === openId);
-
-    navigate(location.pathname, { replace: true, state: {} });
-
-    if (!statement?.storageUrl) return;
-
-    if (pdfUrlRef.current && pdfSourceRef.current === 'generated') {
-      URL.revokeObjectURL(pdfUrlRef.current);
-    }
-    setPdfUrl(statement.storageUrl);
-    setPdfSource('stored');
-    setSelectedStored(openId);
-    setError(null);
-  }, [storedStatements, storedLoading, location.state, location.pathname, navigate]);
 
   const handleOpenStored = () => {
     if (!selectedStored) return;

--- a/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
+++ b/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Box,
   Typography,
@@ -12,35 +12,30 @@ import {
   InputLabel,
   Card,
   CardContent,
-  Divider,
 } from '@mui/material';
 import {
   Download as DownloadIcon,
-  Refresh as RefreshIcon,
   FolderOpen as ArchiveIcon,
   NoteAdd as GenerateIcon,
 } from '@mui/icons-material';
 import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuthStable.jsx';
 import { useSelectedUnit } from '../../context/SelectedUnitContext.jsx';
 import { config } from '../../config/index.js';
 import { auth, db } from '../../services/firebase';
-import { getMexicoDate } from '../../utils/timezone.js';
 import { LoadingSpinner } from '../common';
+import { buildDedupedStoredStatementsForUi } from '../../utils/storedStatementLabels.js';
 
 const API_BASE_URL = config.api.baseUrl;
 
-const MONTH_NAMES = [
-  '', 'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
-];
-
 const StatementPdfViewer = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
   const { currentClient, firebaseUser } = useAuth();
   const { selectedUnitId } = useSelectedUnit();
 
   const clientId = typeof currentClient === 'string' ? currentClient : currentClient?.id;
-  const currentYear = getMexicoDate().getFullYear();
 
   // Stored statements state
   const [storedStatements, setStoredStatements] = useState([]);
@@ -54,10 +49,10 @@ const StatementPdfViewer = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const yearOptions = [];
-  for (let y = currentYear; y >= currentYear - 3; y--) {
-    yearOptions.push(y);
-  }
+  const pdfSourceRef = useRef(pdfSource);
+  const pdfUrlRef = useRef(pdfUrl);
+  pdfSourceRef.current = pdfSource;
+  pdfUrlRef.current = pdfUrl;
 
   // Fetch stored statement metadata from Firestore
   const fetchStoredStatements = useCallback(async () => {
@@ -108,34 +103,32 @@ const StatementPdfViewer = () => {
     };
   }, [pdfUrl, pdfSource]);
 
-  // Deduplicate by year+month+language, keeping most recent generation
-  const storedOptions = (() => {
-    const deduped = new Map();
-    for (const s of storedStatements) {
-      const langLabel = (s.language || 'english').toLowerCase() === 'spanish' ? 'ES' : 'EN';
-      const key = `${s.calendarYear}-${s.calendarMonth}-${langLabel}`;
+  const storedOptions = buildDedupedStoredStatementsForUi(storedStatements);
 
-      const existing = deduped.get(key);
-      if (!existing) {
-        deduped.set(key, s);
-      } else {
-        const existingTime = existing.reportGenerated?._seconds || 0;
-        const currentTime = s.reportGenerated?._seconds || 0;
-        if (currentTime > existingTime) {
-          deduped.set(key, s);
-        }
-      }
+  // Deep-link from My Unit (and similar): open stored PDF in-app like this screen's iframe viewer
+  useEffect(() => {
+    const openId = location.state?.openStoredStatementId;
+    if (!openId || storedLoading) return;
+
+    if (!storedStatements.length) {
+      navigate(location.pathname, { replace: true, state: {} });
+      return;
     }
 
-    return Array.from(deduped.values()).map((s) => {
-      const langLabel = (s.language || 'english').toLowerCase() === 'spanish' ? 'ES' : 'EN';
-      const monthName = MONTH_NAMES[s.calendarMonth] || `Month ${s.calendarMonth}`;
-      return {
-        ...s,
-        label: `${monthName} ${s.calendarYear} (${langLabel})`,
-      };
-    });
-  })();
+    const statement = storedStatements.find((s) => s.id === openId);
+
+    navigate(location.pathname, { replace: true, state: {} });
+
+    if (!statement?.storageUrl) return;
+
+    if (pdfUrlRef.current && pdfSourceRef.current === 'generated') {
+      URL.revokeObjectURL(pdfUrlRef.current);
+    }
+    setPdfUrl(statement.storageUrl);
+    setPdfSource('stored');
+    setSelectedStored(openId);
+    setError(null);
+  }, [storedStatements, storedLoading, location.state, location.pathname, navigate]);
 
   const handleOpenStored = () => {
     if (!selectedStored) return;

--- a/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
+++ b/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
@@ -40,9 +40,9 @@ const StatementPdfViewer = () => {
 
   const clientId = typeof currentClient === 'string' ? currentClient : currentClient?.id;
 
-  // Stored statements state
+  // Stored statements state — start true so deep-link effect does not clear router state before first fetch runs
   const [storedStatements, setStoredStatements] = useState([]);
-  const [storedLoading, setStoredLoading] = useState(false);
+  const [storedLoading, setStoredLoading] = useState(true);
   const [selectedStored, setSelectedStored] = useState('');
 
   // Generate state
@@ -58,7 +58,11 @@ const StatementPdfViewer = () => {
 
   // Fetch stored statement metadata from Firestore
   const fetchStoredStatements = useCallback(async () => {
-    if (!clientId || !selectedUnitId) return;
+    if (!clientId || !selectedUnitId) {
+      setStoredStatements([]);
+      setStoredLoading(false);
+      return;
+    }
 
     try {
       setStoredLoading(true);
@@ -276,7 +280,7 @@ const StatementPdfViewer = () => {
           </Box>
 
           <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
-            Uses your menu language ({preferredLanguageUi === 'ES' ? 'Español' : 'English'}). Change in the sidebar menu under Language / Idioma.
+            Uses your session language ({preferredLanguageUi === 'ES' ? 'Español' : 'English'}). Change it from the menu (globe row: Language / Idioma).
           </Typography>
           <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
             <Button

--- a/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
+++ b/frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx
@@ -210,9 +210,15 @@ const StatementPdfViewer = () => {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
               <LoadingSpinner size="small" message="Loading..." />
             </Box>
-          ) : storedOptions.length === 0 ? (
+          ) : storedOptionsAll.length === 0 ? (
             <Typography variant="caption" color="text.secondary">
               No stored statements found for this unit.
+            </Typography>
+          ) : storedOptions.length === 0 ? (
+            <Typography variant="caption" color="text.secondary" component="div">
+              No stored statements in {preferredLanguageUi === 'ES' ? 'Español' : 'English'} for this unit.
+              {' '}
+              Use the menu (Language / Idioma) to switch languages.
             </Typography>
           ) : (
             <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>

--- a/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
+++ b/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
@@ -24,7 +24,11 @@ import {
 } from '@mui/icons-material';
 import { LoadingSpinner } from '../common';
 import { useNavigate } from 'react-router-dom';
-import { buildDedupedStoredStatementsForUi } from '../../utils/storedStatementLabels.js';
+import {
+  buildDedupedStoredStatementsForUi,
+  filterDedupedStatementsByUiLanguage,
+} from '../../utils/storedStatementLabels.js';
+import { useSessionPreferences } from '../../context/SessionPreferencesContext.jsx';
 import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
 import { useAuth } from '../../hooks/useAuthStable.jsx';
 import { useSelectedUnit } from '../../context/SelectedUnitContext.jsx';
@@ -37,6 +41,7 @@ import { formatPesosForDisplay } from '@shared/utils/currencyUtils.js';
 const UnitSubDashboard = () => {
   const navigate = useNavigate();
   const { currentClient } = useAuth();
+  const { preferredLanguageUi } = useSessionPreferences();
   const { selectedUnitId } = useSelectedUnit();
   const { data: unitData, loading: unitLoading, error: unitError } = useUnitAccountStatus(currentClient, selectedUnitId);
 
@@ -114,11 +119,15 @@ const UnitSubDashboard = () => {
   const nonFuture = lineItems.filter((i) => !i.isFuture);
   const recentTx = nonFuture.slice(-10).reverse();
 
-  const statementRowsForCard = buildDedupedStoredStatementsForUi(storedStatements).slice(0, 5);
+  const allStatementRows = buildDedupedStoredStatementsForUi(storedStatements);
+  const preferredLangRows = filterDedupedStatementsByUiLanguage(allStatementRows, preferredLanguageUi);
+  const latestInPreferredLanguage = preferredLangRows[0] || null;
 
-  const handleGenerateStatement = async () => {
+  const handleGenerateStatement = () => {
     navigate('/statement');
   };
+
+  const langHint = preferredLanguageUi === 'ES' ? 'Spanish (Español)' : 'English';
 
   const isPastDue = daysPastDue > 0;
   const amountColor = amountDue > 0 ? (isPastDue ? '#dc2626' : '#1f2937') : '#059669';
@@ -210,40 +219,61 @@ const UnitSubDashboard = () => {
         </CardContent>
       </Card>
 
-      {/* Stored Statements */}
+      {/* Statements — primary: latest in session language; archive on full screen */}
       <Card sx={{ mb: 2, borderRadius: 2 }}>
         <CardContent>
           <Typography variant="subtitle2" color="text.secondary" gutterBottom>Statements</Typography>
           {storedLoading ? (
             <Box display="flex" justifyContent="center" py={1}><LoadingSpinner size="small" /></Box>
-          ) : statementRowsForCard.length === 0 ? (
-            <Typography variant="body2" color="text.secondary">No stored statements</Typography>
           ) : (
-            <List dense disablePadding>
-              {statementRowsForCard.map((s) => (
-                <ListItem key={s.id} disablePadding>
-                  <ListItemText
-                    primary={s.label}
-                    primaryTypographyProps={{ variant: 'body2' }}
-                  />
-                  {s.storageUrl && (
-                    <Button
-                      size="small"
-                      startIcon={<PdfIcon />}
-                      onClick={() => navigate('/statement', { state: { openStoredStatementId: s.id } })}
-                    >
-                      Open
-                    </Button>
+            <>
+              {allStatementRows.length === 0 ? (
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  No stored statements
+                </Typography>
+              ) : (
+                <>
+                  {latestInPreferredLanguage?.storageUrl ? (
+                    <Box sx={{ mb: 1.5 }}>
+                      <Typography variant="body2" sx={{ mb: 0.5 }}>
+                        Latest ({langHint})
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                        {latestInPreferredLanguage.label}
+                      </Typography>
+                      <Button
+                        fullWidth
+                        variant="contained"
+                        startIcon={<PdfIcon />}
+                        onClick={() => navigate('/statement', { state: { openStoredStatementId: latestInPreferredLanguage.id } })}
+                        sx={{ textTransform: 'none' }}
+                      >
+                        Open latest statement
+                      </Button>
+                    </Box>
+                  ) : (
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      No stored statement in {langHint} for this unit yet.
+                    </Typography>
                   )}
-                </ListItem>
-              ))}
-            </List>
+                </>
+              )}
+              <Button
+                fullWidth
+                variant="text"
+                size="small"
+                onClick={() => navigate('/statement')}
+                sx={{ textTransform: 'none', mb: 1 }}
+              >
+                Other statements / Otros estados de cuenta
+              </Button>
+            </>
           )}
           <Button
             fullWidth
-            variant="contained"
+            variant="outlined"
             startIcon={<GenerateIcon />}
-            sx={{ mt: 1 }}
+            sx={{ mt: 0.5 }}
             onClick={handleGenerateStatement}
           >
             Generate Current Statement

--- a/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
+++ b/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
@@ -84,7 +84,7 @@ const UnitSubDashboard = () => {
 
   useEffect(() => {
     setInlinePdfUrl(null);
-  }, [selectedUnitId, clientId]);
+  }, [selectedUnitId, clientId, preferredLanguageUi]);
 
   if (!currentClient || !selectedUnitId) {
     return (

--- a/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
+++ b/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
@@ -134,7 +134,7 @@ const UnitSubDashboard = () => {
     navigate('/statement');
   };
 
-  const langHint = preferredLanguageUi === 'ES' ? 'Spanish (Español)' : 'English';
+  const langHint = preferredLanguageUi === 'ES' ? 'Español' : 'English';
 
   const isPastDue = daysPastDue > 0;
   const amountColor = amountDue > 0 ? (isPastDue ? '#dc2626' : '#1f2937') : '#059669';

--- a/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
+++ b/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
@@ -48,6 +48,8 @@ const UnitSubDashboard = () => {
   const [transactionsExpanded, setTransactionsExpanded] = useState(true);
   const [storedStatements, setStoredStatements] = useState([]);
   const [storedLoading, setStoredLoading] = useState(false);
+  /** Latest SoA PDF shown inline on My Unit (avoids navigation + re-select). */
+  const [inlinePdfUrl, setInlinePdfUrl] = useState(null);
 
   const clientId = typeof currentClient === 'string' ? currentClient : currentClient?.id;
   const { hoaConfig } = useHoaConfig(clientId);
@@ -79,6 +81,10 @@ const UnitSubDashboard = () => {
   useEffect(() => {
     fetchStoredStatements();
   }, [fetchStoredStatements]);
+
+  useEffect(() => {
+    setInlinePdfUrl(null);
+  }, [selectedUnitId, clientId]);
 
   if (!currentClient || !selectedUnitId) {
     return (
@@ -124,6 +130,7 @@ const UnitSubDashboard = () => {
   const latestInPreferredLanguage = preferredLangRows[0] || null;
 
   const handleGenerateStatement = () => {
+    setInlinePdfUrl(null);
     navigate('/statement');
   };
 
@@ -245,11 +252,35 @@ const UnitSubDashboard = () => {
                         fullWidth
                         variant="contained"
                         startIcon={<PdfIcon />}
-                        onClick={() => navigate('/statement', { state: { openStoredStatementId: latestInPreferredLanguage.id } })}
+                        onClick={() => setInlinePdfUrl(latestInPreferredLanguage.storageUrl)}
                         sx={{ textTransform: 'none' }}
                       >
                         Open latest statement
                       </Button>
+                      {inlinePdfUrl && (
+                        <Box sx={{ mt: 2 }}>
+                          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 0.5 }}>
+                            <Button size="small" onClick={() => setInlinePdfUrl(null)} sx={{ textTransform: 'none' }}>
+                              Close
+                            </Button>
+                          </Box>
+                          <Box
+                            sx={{
+                              border: '1px solid #e0e0e0',
+                              borderRadius: 1,
+                              overflow: 'hidden',
+                              minHeight: 320,
+                              bgcolor: '#fafafa',
+                            }}
+                          >
+                            <iframe
+                              title="Statement of Account"
+                              src={inlinePdfUrl}
+                              style={{ width: '100%', height: 360, border: 'none', display: 'block' }}
+                            />
+                          </Box>
+                        </Box>
+                      )}
                     </Box>
                   ) : (
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
@@ -262,7 +293,10 @@ const UnitSubDashboard = () => {
                 fullWidth
                 variant="text"
                 size="small"
-                onClick={() => navigate('/statement')}
+                onClick={() => {
+                  setInlinePdfUrl(null);
+                  navigate('/statement');
+                }}
                 sx={{ textTransform: 'none', mb: 1 }}
               >
                 Other statements / Otros estados de cuenta

--- a/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
+++ b/frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx
@@ -24,6 +24,7 @@ import {
 } from '@mui/icons-material';
 import { LoadingSpinner } from '../common';
 import { useNavigate } from 'react-router-dom';
+import { buildDedupedStoredStatementsForUi } from '../../utils/storedStatementLabels.js';
 import { collection, query, where, getDocs, orderBy } from 'firebase/firestore';
 import { useAuth } from '../../hooks/useAuthStable.jsx';
 import { useSelectedUnit } from '../../context/SelectedUnitContext.jsx';
@@ -112,6 +113,8 @@ const UnitSubDashboard = () => {
   const lineItems = unitData?.lineItems || [];
   const nonFuture = lineItems.filter((i) => !i.isFuture);
   const recentTx = nonFuture.slice(-10).reverse();
+
+  const statementRowsForCard = buildDedupedStoredStatementsForUi(storedStatements).slice(0, 5);
 
   const handleGenerateStatement = async () => {
     navigate('/statement');
@@ -213,18 +216,22 @@ const UnitSubDashboard = () => {
           <Typography variant="subtitle2" color="text.secondary" gutterBottom>Statements</Typography>
           {storedLoading ? (
             <Box display="flex" justifyContent="center" py={1}><LoadingSpinner size="small" /></Box>
-          ) : storedStatements.length === 0 ? (
+          ) : statementRowsForCard.length === 0 ? (
             <Typography variant="body2" color="text.secondary">No stored statements</Typography>
           ) : (
             <List dense disablePadding>
-              {storedStatements.slice(0, 5).map((s) => (
+              {statementRowsForCard.map((s) => (
                 <ListItem key={s.id} disablePadding>
                   <ListItemText
-                    primary={`${s.calendarMonth || ''}/${s.calendarYear || ''}`}
+                    primary={s.label}
                     primaryTypographyProps={{ variant: 'body2' }}
                   />
                   {s.storageUrl && (
-                    <Button size="small" startIcon={<PdfIcon />} href={s.storageUrl} target="_blank" rel="noopener">
+                    <Button
+                      size="small"
+                      startIcon={<PdfIcon />}
+                      onClick={() => navigate('/statement', { state: { openStoredStatementId: s.id } })}
+                    >
                       Open
                     </Button>
                   )}

--- a/frontend/mobile-app/src/context/SessionPreferencesContext.jsx
+++ b/frontend/mobile-app/src/context/SessionPreferencesContext.jsx
@@ -1,0 +1,82 @@
+/**
+ * Session-only preferences for mobile PWA (issue #251 extension).
+ * Seeded from user profile on login when fields exist; never written back to profile from this app.
+ * Hamburger Language | Idioma toggles EN/ES for this session only.
+ */
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useAuth } from '../hooks/useAuthStable.jsx';
+import { normalizeProfileLanguageToUi, uiLanguageToStatementApi } from '../utils/sessionLanguage.js';
+
+const SessionPreferencesContext = createContext(null);
+
+export function SessionPreferencesProvider({ children }) {
+  const { firebaseUser, samsUser } = useAuth();
+  const [preferredLanguageUi, setPreferredLanguageUi] = useState('EN');
+  /** Stub for future profile field + downstream formatting */
+  const [preferredCurrency, setPreferredCurrency] = useState('MXN');
+  const seededForUidRef = useRef(null);
+
+  useEffect(() => {
+    if (!firebaseUser) {
+      seededForUidRef.current = null;
+      setPreferredLanguageUi('EN');
+      setPreferredCurrency('MXN');
+      return;
+    }
+
+    if (!samsUser) return;
+
+    const uid = firebaseUser.uid;
+    if (seededForUidRef.current === uid) return;
+    seededForUidRef.current = uid;
+
+    // When backend adds preferredLanguage / preferredCurrency to getProfile(), they apply here.
+    const rawLang = samsUser.preferredLanguage ?? samsUser.preferred_language;
+    setPreferredLanguageUi(normalizeProfileLanguageToUi(rawLang));
+
+    const rawCur = samsUser.preferredCurrency ?? samsUser.preferred_currency;
+    if (rawCur != null && String(rawCur).trim() !== '') {
+      setPreferredCurrency(String(rawCur).trim().toUpperCase());
+    } else {
+      setPreferredCurrency('MXN');
+    }
+  }, [firebaseUser, samsUser]);
+
+  const statementLanguageApi = useMemo(
+    () => uiLanguageToStatementApi(preferredLanguageUi),
+    [preferredLanguageUi],
+  );
+
+  const value = useMemo(
+    () => ({
+      preferredLanguageUi,
+      setPreferredLanguageUi,
+      statementLanguageApi,
+      preferredCurrency,
+    }),
+    [preferredLanguageUi, statementLanguageApi, preferredCurrency],
+  );
+
+  return (
+    <SessionPreferencesContext.Provider value={value}>
+      {children}
+    </SessionPreferencesContext.Provider>
+  );
+}
+
+export function useSessionPreferences() {
+  const ctx = useContext(SessionPreferencesContext);
+  if (!ctx) {
+    throw new Error('useSessionPreferences must be used within SessionPreferencesProvider');
+  }
+  return ctx;
+}
+
+export default SessionPreferencesContext;

--- a/frontend/mobile-app/src/context/SessionPreferencesContext.jsx
+++ b/frontend/mobile-app/src/context/SessionPreferencesContext.jsx
@@ -37,11 +37,20 @@ export function SessionPreferencesProvider({ children }) {
     if (seededForUidRef.current === uid) return;
     seededForUidRef.current = uid;
 
-    // When backend adds preferredLanguage / preferredCurrency to getProfile(), they apply here.
-    const rawLang = samsUser.preferredLanguage ?? samsUser.preferred_language;
+    // getProfile() nests prefs under profile: { preferredLanguage, preferredCurrency }
+    const prof = samsUser.profile || {};
+    const rawLang =
+      prof.preferredLanguage ??
+      prof.preferred_language ??
+      samsUser.preferredLanguage ??
+      samsUser.preferred_language;
     setPreferredLanguageUi(normalizeProfileLanguageToUi(rawLang));
 
-    const rawCur = samsUser.preferredCurrency ?? samsUser.preferred_currency;
+    const rawCur =
+      prof.preferredCurrency ??
+      prof.preferred_currency ??
+      samsUser.preferredCurrency ??
+      samsUser.preferred_currency;
     if (rawCur != null && String(rawCur).trim() !== '') {
       setPreferredCurrency(String(rawCur).trim().toUpperCase());
     } else {

--- a/frontend/mobile-app/src/utils/sessionLanguage.js
+++ b/frontend/mobile-app/src/utils/sessionLanguage.js
@@ -1,0 +1,17 @@
+/**
+ * Session UI language (EN | ES) vs statement PDF API (`english` | `spanish`).
+ * Profile may later expose preferredLanguage; until then we default to EN.
+ */
+
+/** @returns {'EN'|'ES'} */
+export function normalizeProfileLanguageToUi(raw) {
+  if (raw == null || raw === '') return 'EN';
+  const s = String(raw).trim().toLowerCase();
+  if (s === 'es' || s === 'spanish' || s === 'esp' || s === 'es-mx' || s === 'es_mx') return 'ES';
+  return 'EN';
+}
+
+/** @returns {'english'|'spanish'} */
+export function uiLanguageToStatementApi(ui) {
+  return ui === 'ES' ? 'spanish' : 'english';
+}

--- a/frontend/mobile-app/src/utils/storedStatementLabels.js
+++ b/frontend/mobile-app/src/utils/storedStatementLabels.js
@@ -29,6 +29,12 @@ export function formatStoredStatementLabel(statement) {
  * Deduplicate by calendarYear + calendarMonth + language; keep newest reportGenerated.
  * Returns statements with .label for UI (e.g. "March 2026 (EN)").
  */
+/** @param {Array<{ label?: string }>} dedupedRows from buildDedupedStoredStatementsForUi */
+export function filterDedupedStatementsByUiLanguage(dedupedRows, uiLanguageCode) {
+  const want = uiLanguageCode === 'ES' ? 'ES' : 'EN';
+  return (dedupedRows || []).filter((s) => statementLanguageCode(s) === want);
+}
+
 export function buildDedupedStoredStatementsForUi(storedStatements) {
   const list = Array.isArray(storedStatements) ? storedStatements : [];
   const deduped = new Map();

--- a/frontend/mobile-app/src/utils/storedStatementLabels.js
+++ b/frontend/mobile-app/src/utils/storedStatementLabels.js
@@ -1,0 +1,60 @@
+/**
+ * Shared labels for mobile stored Statement of Account rows (issue #251).
+ * Firestore accountStatements: calendarMonth 1-12, calendarYear, language, storageUrl, etc.
+ */
+
+const MONTH_NAMES_EN = [
+  '', 'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+export function statementLanguageCode(statement) {
+  if (!statement) return 'EN';
+  const lang = (statement.language || 'english').toLowerCase();
+  return lang === 'spanish' ? 'ES' : 'EN';
+}
+
+export function formatStoredStatementLabel(statement) {
+  const langLabel = statementLanguageCode(statement);
+  const m = statement?.calendarMonth;
+  const monthNum = typeof m === 'number' ? m : parseInt(String(m ?? ''), 10);
+  const monthName = (monthNum >= 1 && monthNum <= 12)
+    ? MONTH_NAMES_EN[monthNum]
+    : (m != null && m !== '' ? `Month ${m}` : 'Unknown month');
+  const year = statement?.calendarYear ?? '';
+  return `${monthName} ${year} (${langLabel})`.trim();
+}
+
+/**
+ * Deduplicate by calendarYear + calendarMonth + language; keep newest reportGenerated.
+ * Returns statements with .label for UI (e.g. "March 2026 (EN)").
+ */
+export function buildDedupedStoredStatementsForUi(storedStatements) {
+  const list = Array.isArray(storedStatements) ? storedStatements : [];
+  const deduped = new Map();
+  for (const s of list) {
+    const langLabel = statementLanguageCode(s);
+    const key = `${s.calendarYear}-${s.calendarMonth}-${langLabel}`;
+    const existing = deduped.get(key);
+    if (!existing) {
+      deduped.set(key, s);
+    } else {
+      const existingTime = existing.reportGenerated?._seconds || 0;
+      const currentTime = s.reportGenerated?._seconds || 0;
+      if (currentTime > existingTime) {
+        deduped.set(key, s);
+      }
+    }
+  }
+  return Array.from(deduped.values())
+    .map((s) => ({ ...s, label: formatStoredStatementLabel(s) }))
+    .sort((a, b) => {
+      if ((b.calendarYear || 0) !== (a.calendarYear || 0)) {
+        return (b.calendarYear || 0) - (a.calendarYear || 0);
+      }
+      if ((b.calendarMonth || 0) !== (a.calendarMonth || 0)) {
+        return (b.calendarMonth || 0) - (a.calendarMonth || 0);
+      }
+      return statementLanguageCode(a).localeCompare(statementLanguageCode(b));
+    });
+}


### PR DESCRIPTION
## Summary

Fixes #251.

### Root cause

- **My Unit** (`/unit-dashboard`, `UnitSubDashboard`) listed stored statements as `month/year` with no language, and **Open** used `target="_blank"`, so PDFs opened in a new tab/window.
- **More → Statement of Account** (`StatementPdfViewer`) used a dropdown with **month name + (EN)/(ES)** and opened stored PDFs **in-app** via an iframe.

Two different UX paths for the same Firestore `accountStatements` data.

### Changes

| File | Change |
|------|--------|
| `frontend/mobile-app/src/utils/storedStatementLabels.js` | **New** — shared `formatStoredStatementLabel`, dedupe by year/month/language, sort |
| `frontend/mobile-app/src/components/owner/UnitSubDashboard.jsx` | Same labels as statement screen; **Open** → `navigate('/statement', { state: { openStoredStatementId } })` |
| `frontend/mobile-app/src/components/owner/StatementPdfViewer.jsx` | Uses shared labels for dropdown; consumes `openStoredStatementId` from location state; removed dead `yearOptions` / unused imports |

### Before / after

| | Before | After |
|--|--------|--------|
| My Unit row label | e.g. `3/2026` | e.g. `March 2026 (EN)` |
| My Unit Open | New tab (`href` + `target="_blank"`) | Same in-app iframe flow as More → Statement |
| More → Statement | Unchanged behavior (still iframe + labels) | Aligned label/dedupe logic with My Unit via shared util |

### Backend

**No backend or API contract changes.** Frontend-only.

### Test evidence

| Check | Status |
|-------|--------|
| `npm run build` (mobile-app) | Pass |
| `bash scripts/pre-pr-checks.sh main` | Pass |
| Manual PWA (My Unit + More, EN/ES, edge cases) | Owner testing in emulator |

### Notes for reviewers / BugBot

- Deep-link state is cleared with `replace` after handling `openStoredStatementId`.
- Empty stored list after fetch still clears router state to avoid a stuck deep link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UX risk: changes how stored statements are filtered/shown by session language and how PDFs are opened (inline iframe vs links), which could make statements appear missing or fail to open if edge cases weren’t handled.
> 
> **Overview**
> Unifies Statement of Account behavior across the owner flows by introducing a session-only preferences context (currently used for **EN/ES UI language**) and exposing a hamburger-menu language toggle.
> 
> Stored statement labeling/deduping is centralized in `storedStatementLabels.js` and reused in both `UnitSubDashboard` and `StatementPdfViewer`, with the statement screen now filtering the dropdown to the current session language and using that session language when generating PDFs.
> 
> The owner **My Unit** dashboard now prioritizes the *latest stored statement in the session language* with an inline PDF viewer, links to the full `/statement` archive, and removes the duplicate SoA entry from `MoreMenu`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a7b21e208eabecd4c38d228945350e1c9b2b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->