### PR TITLE
fix(dates): remove raw Date usage in exchange-rate health check (#254)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -5,6 +5,7 @@ import admin from 'firebase-admin';
 
 // Import existing exchange rate functions
 import { updateExchangeRates, populateHistoricalRates } from './src/exchangeRatesUpdater.js';
+import { getMexicoDateString, getMexicoYesterdayString } from './src/utils/timezone.js';
 import { syncExchangeRatesToDev } from './src/syncToDevDatabase.js';
 import { loadTwoYearsHistoricalData, loadHistoricalDataForYear } from './src/bulkHistoricalLoader.js';
 
@@ -172,8 +173,9 @@ export const checkExchangeRatesHealth = onRequest(
   async (req, res) => {
     try {
       const db = admin.firestore();
-      const today = new Date().toISOString().split('T')[0];
-      const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+      // Doc IDs match updateExchangeRates: America/Cancun calendar YYYY-MM-DD (not UTC ISO date).
+      const today = getMexicoDateString();
+      const yesterday = getMexicoYesterdayString();
       
       const [todayDoc, yesterdayDoc] = await Promise.all([
         db.collection('exchangeRates').doc(today).get(),


### PR DESCRIPTION
## Issue
Closes https://github.com/mlandesman/SAMS/issues/254

## Document ID contract
**America/Cancun calendar `YYYY-MM-DD`.** `updateExchangeRates` writes `exchangeRates` docs with `getMexicoDateString()` (see `functions/src/exchangeRatesUpdater.js` + `functions/src/utils/timezone.js`). This is **not** a UTC-day contract.

## Before / after
| | Before | After |
|---|--------|--------|
| Today key | `new Date().toISOString().split('T')[0]` (UTC date) | `getMexicoDateString()` (Cancun) |
| Yesterday key | `86400000` ms + UTC ISO date | `getMexicoYesterdayString()` |

## What changed
- `functions/index.js`: `checkExchangeRatesHealth` imports Mexico date helpers used by the rate updater; response JSON shape unchanged.

## Test evidence
- Static: no `new Date()` / `Date.now()` in the handler.
- Runtime (helpers): `node -e "import('./src/utils/timezone.js').then(m => console.log(m.getMexicoDateString(), m.getMexicoYesterdayString()))"` in `functions/` → Cancun `YYYY-MM-DD` pairs (see task completion log on disk; log path is gitignored).

## Checklist
- [x] Aligns health lookups with writer doc IDs
- [ ] BugBot / CI clean

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the `checkExchangeRatesHealth` lookup keys from UTC-derived dates to the same Mexico (America/Cancun) date helpers used by the writer, avoiding false negatives around day boundaries.
> 
> **Overview**
> Updates `checkExchangeRatesHealth` to stop deriving `today`/`yesterday` doc IDs from UTC `Date` values and instead use `getMexicoDateString()` / `getMexicoYesterdayString()`.
> 
> This aligns health-check reads with the `exchangeRates` document ID contract (Mexico calendar `YYYY-MM-DD`) while keeping the endpoint response shape and query logic the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0f8711115a82f9d8167d5c5e6a707fcefa1f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->