### PR TITLE
fix(dashboard): correct budget units and deduct credit balances (#288, #96)

### DIFF
--- a/frontend/sams-ui/mobile-app/src/components/Dashboard.jsx
+++ b/frontend/sams-ui/mobile-app/src/components/Dashboard.jsx
@@ -134,10 +134,18 @@ const Dashboard = () => {
                       <span>Bank Accounts:</span>
                       <strong>${accountBalances.bank?.toLocaleString() || '0'}</strong>
                     </Typography>
-                    <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
                       <span>Cash Accounts:</span>
                       <strong>${accountBalances.cash?.toLocaleString() || '0'}</strong>
                     </Typography>
+                    {(accountBalances.unitCreditsPesos || 0) > 0 && (
+                      <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                        <span>Unit credits:</span>
+                        <strong style={{ color: '#b45309' }}>
+                          −${Math.round(accountBalances.unitCreditsPesos).toLocaleString()}
+                        </strong>
+                      </Typography>
+                    )}
                   </Box>
                 </>
               )}

--- a/frontend/sams-ui/mobile-app/src/components/Dashboard.jsx
+++ b/frontend/sams-ui/mobile-app/src/components/Dashboard.jsx
@@ -126,10 +126,10 @@ const Dashboard = () => {
                   <Typography variant="h4" sx={{ color: '#0863bf', fontWeight: 700, mb: 1 }}>
                     ${accountBalances.total?.toLocaleString() || '0'}
                   </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                    Total Balance
+                  <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+                    Bank + Cash − Credit Balances
                   </Typography>
-                  <Box sx={{ mt: 2 }}>
+                  <Box sx={{ mt: 2, pt: 1, borderTop: '1px solid rgba(0,0,0,0.08)' }}>
                     <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
                       <span>Bank Accounts:</span>
                       <strong>${accountBalances.bank?.toLocaleString() || '0'}</strong>
@@ -140,9 +140,9 @@ const Dashboard = () => {
                     </Typography>
                     {(accountBalances.unitCreditsPesos || 0) > 0 && (
                       <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-                        <span>Unit credits:</span>
-                        <strong style={{ color: '#b45309' }}>
-                          −${Math.round(accountBalances.unitCreditsPesos).toLocaleString()}
+                        <span style={{ color: 'rgba(0,0,0,0.6)' }}>Credit Balances</span>
+                        <strong>
+                          ${Math.round(accountBalances.unitCreditsPesos).toLocaleString()}
                         </strong>
                       </Typography>
                     )}

--- a/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
@@ -115,13 +115,15 @@ export const useDashboardData = () => {
   const accountBalances = useMemo(() => {
     const gross = accountBalancesBeforeCredit.total || 0;
     const credit = unitCreditTotalPesos || 0;
-    const netTotal = Math.round(gross - credit);
+    const accountsFailed = Boolean(error.accounts);
+    const creditApplied = accountsFailed ? 0 : credit;
+    const netTotal = Math.round(gross - creditApplied);
     return {
       ...accountBalancesBeforeCredit,
       total: netTotal,
-      unitCreditsPesos: credit
+      unitCreditsPesos: accountsFailed ? 0 : credit
     };
-  }, [accountBalancesBeforeCredit, unitCreditTotalPesos]);
+  }, [accountBalancesBeforeCredit, unitCreditTotalPesos, error.accounts]);
 
   // Fetch HOA dues status - same logic as Desktop UI
   useEffect(() => {

--- a/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
@@ -4,6 +4,18 @@ import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
 import { db } from '../services/firebase.js';
 import { getMexicoDate } from '../utils/timezone.js';
 
+/**
+ * Current credit balance in centavos from one unit's slice of `units/creditBalances` (history journal).
+ * Same algorithm as shared getCreditBalance — inlined to avoid bundling Node DateService/firebase-admin.
+ */
+function creditBalanceCentavosFromHistory(unitCreditDoc) {
+  if (!unitCreditDoc?.history || !Array.isArray(unitCreditDoc.history)) return 0;
+  return unitCreditDoc.history.reduce((sum, entry) => {
+    const amount = typeof entry.amount === 'number' ? entry.amount : 0;
+    return sum + amount;
+  }, 0);
+}
+
 export const useDashboardData = () => {
   const { samsUser, currentClient } = useAuth();
 
@@ -14,7 +26,7 @@ export const useDashboardData = () => {
     cash: 0,
     accounts: []
   });
-  /** Sum of positive unit creditBalance from dues/{year} (Firestore centavos → pesos). Same intent as HOADuesView.calculateTotalCredit(). */
+  /** Sum of positive unit credits from `units/creditBalances` history (centavos → pesos). Matches getAllDuesDataForYear / HOADuesView.calculateTotalCredit(). */
   const [unitCreditTotalPesos, setUnitCreditTotalPesos] = useState(0);
   
   const [hoaDuesStatus, setHoaDuesStatus] = useState({
@@ -160,6 +172,12 @@ export const useDashboardData = () => {
         if (units.length === 0) {
           throw new Error('No units found for this client');
         }
+
+        // Centralized credit (same source as getAllDuesDataForYear / desktop API) — not on per-unit dues docs
+        const creditBalancesSnap = await getDoc(
+          doc(db, `clients/${currentClient}/units/creditBalances`)
+        );
+        const allCreditData = creditBalancesSnap.exists() ? creditBalancesSnap.data() || {} : {};
         
         // Calculate Annual Dues (total amount each unit should pay x 12)
         const annualDuesTotal = units.reduce((total, unit) => {
@@ -224,13 +242,13 @@ export const useDashboardData = () => {
             }
           }
           
-          // Credits in Firestore are centavos; add to collection math in centavos.
-          const unitCreditBalance = unitDues?.creditBalance || 0;
-          if (unitCreditBalance > 0) {
-            totalCreditCentavos += unitCreditBalance;
+          // Credits: centavos from units/creditBalances (authoritative), not dues/{year} snapshots
+          const creditCentavos = creditBalanceCentavosFromHistory(allCreditData[unit.id] || {});
+          if (creditCentavos > 0) {
+            totalCreditCentavos += creditCentavos;
           }
-          totalCollected += unitCreditBalance;
-          unitPaidTotal += unitCreditBalance;
+          totalCollected += creditCentavos;
+          unitPaidTotal += creditCentavos;
           
           // Calculate past due amount for this unit (including credits)
           if (unitPaidTotal < shouldHavePaidByNow) {

--- a/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
@@ -3,18 +3,10 @@ import { useAuth } from './useAuthStable.jsx';
 import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
 import { db } from '../services/firebase.js';
 import { getMexicoDate } from '../utils/timezone.js';
-
-/**
- * Current credit balance in centavos from one unit's slice of `units/creditBalances` (history journal).
- * Same algorithm as shared getCreditBalance — inlined to avoid bundling Node DateService/firebase-admin.
- */
-function creditBalanceCentavosFromHistory(unitCreditDoc) {
-  if (!unitCreditDoc?.history || !Array.isArray(unitCreditDoc.history)) return 0;
-  return unitCreditDoc.history.reduce((sum, entry) => {
-    const amount = typeof entry.amount === 'number' ? entry.amount : 0;
-    return sum + amount;
-  }, 0);
-}
+import {
+  getCreditBalanceCentavos,
+  totalCreditCentavosPositiveFromCreditBalancesRoot
+} from '@shared/utils/hoaCreditTotals';
 
 export const useDashboardData = () => {
   const { samsUser, currentClient } = useAuth();
@@ -196,7 +188,6 @@ export const useDashboardData = () => {
         let currentMonthCollected = 0;
         let pastDueUnits = 0;
         let pastDueAmount = 0;
-        let totalCreditCentavos = 0;
         const monthsElapsed = currentMonth; // How many months of the year have passed
         
         for (const unit of units) {
@@ -242,11 +233,8 @@ export const useDashboardData = () => {
             }
           }
           
-          // Credits: centavos from units/creditBalances (authoritative), not dues/{year} snapshots
-          const creditCentavos = creditBalanceCentavosFromHistory(allCreditData[unit.id] || {});
-          if (creditCentavos > 0) {
-            totalCreditCentavos += creditCentavos;
-          }
+          // Credits: centavos from units/creditBalances (shared getCreditBalanceCentavos)
+          const creditCentavos = getCreditBalanceCentavos(allCreditData[unit.id] || {});
           totalCollected += creditCentavos;
           unitPaidTotal += creditCentavos;
           
@@ -277,6 +265,10 @@ export const useDashboardData = () => {
         console.log('🚨 Past Due Units Count:', pastDueUnits);
         console.log('💸 Past Due Amount:', pastDueAmount.toLocaleString());
 
+        const totalCreditCentavos = totalCreditCentavosPositiveFromCreditBalancesRoot(
+          allCreditData,
+          units.map((u) => u.id)
+        );
         setUnitCreditTotalPesos(totalCreditCentavos / 100);
         
         setHoaDuesStatus({

--- a/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/mobile-app/src/hooks/useDashboardData.js
@@ -1,17 +1,21 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useAuth } from './useAuthStable.jsx';
 import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
 import { db } from '../services/firebase.js';
+import { getMexicoDate } from '../utils/timezone.js';
 
 export const useDashboardData = () => {
   const { samsUser, currentClient } = useAuth();
-  
-  const [accountBalances, setAccountBalances] = useState({
+
+  /** Gross bank+cash in pesos (rounded); headline total deducts unit credits (matches desktop sams-ui). */
+  const [accountBalancesBeforeCredit, setAccountBalancesBeforeCredit] = useState({
     total: 0,
     bank: 0,
     cash: 0,
     accounts: []
   });
+  /** Sum of positive unit creditBalance from dues/{year} (Firestore centavos → pesos). Same intent as HOADuesView.calculateTotalCredit(). */
+  const [unitCreditTotalPesos, setUnitCreditTotalPesos] = useState(0);
   
   const [hoaDuesStatus, setHoaDuesStatus] = useState({
     totalDue: 0,
@@ -41,29 +45,36 @@ export const useDashboardData = () => {
     rates: null
   });
 
-  // Fetch account balances - simplified version for PWA
+  // Fetch account balances from Firestore (amounts stored as centavos — match desktop /balances/current display)
   useEffect(() => {
     const fetchAccountBalances = async () => {
-      if (!currentClient || !samsUser) return;
-      
+      if (!currentClient || !samsUser) {
+        setAccountBalancesBeforeCredit({
+          total: 0,
+          bank: 0,
+          cash: 0,
+          accounts: []
+        });
+        setLoading(prev => ({ ...prev, accounts: false }));
+        return;
+      }
+
       try {
         setLoading(prev => ({ ...prev, accounts: true }));
         setError(prev => ({ ...prev, accounts: null }));
-        
-        // Get client document directly from Firestore
+
         const clientDocRef = doc(db, `clients/${currentClient}`);
         const clientSnapshot = await getDoc(clientDocRef);
-        
+
         if (clientSnapshot.exists()) {
           const clientData = clientSnapshot.data();
           const accounts = clientData.accounts || [];
-          
-          // Calculate totals by account type
+
           let bankBalance = 0;
           let cashBalance = 0;
-          
-          accounts.forEach(account => {
-            if (account.active !== false) { // Include active accounts
+
+          accounts.forEach((account) => {
+            if (account.active !== false) {
               const balance = account.balance || 0;
               if (account.type === 'bank') {
                 bankBalance += balance;
@@ -72,25 +83,22 @@ export const useDashboardData = () => {
               }
             }
           });
-          
+
           const totalBalance = bankBalance + cashBalance;
-          
-          setAccountBalances({
-            total: Math.round(totalBalance),
-            bank: Math.round(bankBalance),
-            cash: Math.round(cashBalance),
-            accounts: accounts.filter(acc => acc.active !== false)
+
+          setAccountBalancesBeforeCredit({
+            total: Math.round(totalBalance / 100),
+            bank: Math.round(bankBalance / 100),
+            cash: Math.round(cashBalance / 100),
+            accounts: accounts.filter((acc) => acc.active !== false)
           });
         } else {
           throw new Error('Client data not found');
         }
-        
       } catch (err) {
         console.error('Error fetching account balances:', err);
         setError(prev => ({ ...prev, accounts: err.message }));
-        
-        // Fallback to zero balances on error
-        setAccountBalances({
+        setAccountBalancesBeforeCredit({
           total: 0,
           bank: 0,
           cash: 0,
@@ -104,17 +112,33 @@ export const useDashboardData = () => {
     fetchAccountBalances();
   }, [currentClient, samsUser]);
 
+  const accountBalances = useMemo(() => {
+    const gross = accountBalancesBeforeCredit.total || 0;
+    const credit = unitCreditTotalPesos || 0;
+    const netTotal = Math.round(gross - credit);
+    return {
+      ...accountBalancesBeforeCredit,
+      total: netTotal,
+      unitCreditsPesos: credit
+    };
+  }, [accountBalancesBeforeCredit, unitCreditTotalPesos]);
+
   // Fetch HOA dues status - same logic as Desktop UI
   useEffect(() => {
     const fetchHOADuesStatus = async () => {
-      if (!currentClient || !samsUser) return;
+      if (!currentClient || !samsUser) {
+        setUnitCreditTotalPesos(0);
+        setLoading(prev => ({ ...prev, dues: false }));
+        return;
+      }
       
       try {
+        setUnitCreditTotalPesos(0);
         setLoading(prev => ({ ...prev, dues: true }));
         setError(prev => ({ ...prev, dues: null }));
         
-        // Get current year and month for calculations
-        const currentDate = new Date();
+        // Current calendar context in America/Cancun (same discipline as desktop)
+        const currentDate = getMexicoDate();
         const currentYear = currentDate.getFullYear();
         const currentMonth = currentDate.getMonth() + 1; // 1-12
         
@@ -123,12 +147,12 @@ export const useDashboardData = () => {
         const unitsSnapshot = await getDocs(unitsCollectionRef);
         
         const units = [];
-        unitsSnapshot.forEach(doc => {
-          const unitData = {
-            id: doc.id,
-            ...doc.data()
-          };
-          units.push(unitData);
+        unitsSnapshot.forEach((unitDoc) => {
+          if (unitDoc.id === 'creditBalances') return;
+          units.push({
+            id: unitDoc.id,
+            ...unitDoc.data()
+          });
         });
         
         if (units.length === 0) {
@@ -152,6 +176,7 @@ export const useDashboardData = () => {
         let currentMonthCollected = 0;
         let pastDueUnits = 0;
         let pastDueAmount = 0;
+        let totalCreditCentavos = 0;
         const monthsElapsed = currentMonth; // How many months of the year have passed
         
         for (const unit of units) {
@@ -197,8 +222,11 @@ export const useDashboardData = () => {
             }
           }
           
-          // Add credit balance to total collected and unit paid total (credits count as payments received)
+          // Credits in Firestore are centavos; add to collection math in centavos.
           const unitCreditBalance = unitDues?.creditBalance || 0;
+          if (unitCreditBalance > 0) {
+            totalCreditCentavos += unitCreditBalance;
+          }
           totalCollected += unitCreditBalance;
           unitPaidTotal += unitCreditBalance;
           
@@ -228,6 +256,8 @@ export const useDashboardData = () => {
         console.log('📊 Collection Rate (Current Month):', collectionRate.toFixed(1) + '%');
         console.log('🚨 Past Due Units Count:', pastDueUnits);
         console.log('💸 Past Due Amount:', pastDueAmount.toLocaleString());
+
+        setUnitCreditTotalPesos(totalCreditCentavos / 100);
         
         setHoaDuesStatus({
           totalDue: annualDuesTotal,
@@ -243,6 +273,7 @@ export const useDashboardData = () => {
       } catch (err) {
         console.error('Error fetching HOA dues status:', err);
         setError(prev => ({ ...prev, dues: err.message }));
+        setUnitCreditTotalPesos(0);
         
         // Fallback to zero data on error
         setHoaDuesStatus({

--- a/frontend/sams-ui/mobile-app/vite.config.js
+++ b/frontend/sams-ui/mobile-app/vite.config.js
@@ -79,7 +79,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      // Symlink SAMS/shared/utils → functions/shared/utils (same as sams-ui desktop)
+      '@shared': fileURLToPath(new URL('../../../shared', import.meta.url))
     }
   },
   server: {

--- a/frontend/sams-ui/src/hooks/useBudgetStatus.js
+++ b/frontend/sams-ui/src/hooks/useBudgetStatus.js
@@ -4,6 +4,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useClient } from '../context/ClientContext';
 import reportService from '../services/reportService';
+import { centavosToPesos } from '@shared/utils/currencyUtils';
 
 export function useBudgetStatus() {
   const { selectedClient } = useClient();
@@ -28,28 +29,19 @@ export function useBudgetStatus() {
       //   reportInfo: { fiscalYear, percentOfYearElapsed, ... }
       //   income:     { categories: [...], totals: { totalAnnualBudget, totalYtdBudget, totalYtdActual, totalVariance } }
       //   expenses:   { categories: [...], totals: { totalAnnualBudget, totalYtdBudget, totalYtdActual, totalVariance } }
+      // Totals and category rows are INTEGER CENTAVOS (same as Firestore); convert to pesos for UI.
       const incomeTotals = budgetData.income?.totals || {};
       const expenseTotals = budgetData.expenses?.totals || {};
 
-      // Calculate summary metrics
-      const totalBudget = (incomeTotals.totalAnnualBudget || 0) + 
-                          (expenseTotals.totalAnnualBudget || 0);
-      const totalActual = (incomeTotals.totalYtdActual || 0) + 
-                          (expenseTotals.totalYtdActual || 0);
-      const totalVariance = (incomeTotals.totalVariance || 0) + 
-                            (expenseTotals.totalVariance || 0);
-
-      // Calculate YTD budget based on % of year elapsed
       const percentElapsed = budgetData.reportInfo?.percentOfYearElapsed || 0;
-      const ytdBudget = totalBudget * (percentElapsed / 100);
 
       // Determine status (favorable = actual < budget for expenses, actual > budget for income)
-      // For combined, we look at net position
-      const netBudgetYTD = (incomeTotals.totalYtdBudget || 0) - 
-                           (expenseTotals.totalYtdBudget || 0);
-      const netActual = (incomeTotals.totalYtdActual || 0) - 
-                        Math.abs(expenseTotals.totalYtdActual || 0);
-      const netVariance = netActual - netBudgetYTD;
+      // For combined, we look at net position (centavos → pesos for derived fields)
+      const netBudgetYTDCents = (incomeTotals.totalYtdBudget || 0) -
+        (expenseTotals.totalYtdBudget || 0);
+      const netActualCents = (incomeTotals.totalYtdActual || 0) -
+        Math.abs(expenseTotals.totalYtdActual || 0);
+      const netVarianceCents = netActualCents - netBudgetYTDCents;
 
       // Over-budget watch list: expense categories where actual > budget
       // Variance in BvA is (budget - actual), so negative = over budget
@@ -58,16 +50,20 @@ export function useBudgetStatus() {
         .filter(item => item.ytdBudget > 0 && item.variance < 0)
         .map(item => ({
           category: item.name,
-          overAmount: Math.abs(item.variance),
+          overAmount: centavosToPesos(Math.abs(item.variance)),
           overPercent: Math.round(Math.abs(item.variance / item.ytdBudget) * 100),
         }))
         .sort((a, b) => b.overPercent - a.overPercent)
         .slice(0, 5);
 
       // Expense-only status: are expenses within budget?
-      const expenseYtdBudget = expenseTotals.totalYtdBudget || 0;
-      const expenseYtdActual = Math.abs(expenseTotals.totalYtdActual || 0);
-      const expenseVariance = expenseYtdBudget - expenseYtdActual;
+      const expenseYtdBudgetCents = expenseTotals.totalYtdBudget || 0;
+      const expenseYtdActualCents = Math.abs(expenseTotals.totalYtdActual || 0);
+      const expenseVarianceCents = expenseYtdBudgetCents - expenseYtdActualCents;
+
+      const expenseYtdBudget = centavosToPesos(expenseYtdBudgetCents);
+      const expenseYtdActual = centavosToPesos(expenseYtdActualCents);
+      const expenseVariance = centavosToPesos(expenseVarianceCents);
 
       setData({
         fiscalYear: budgetData.reportInfo?.fiscalYear,
@@ -77,20 +73,20 @@ export function useBudgetStatus() {
         expenseYtdBudget,
         expenseYtdActual,
         expenseVariance,
-        expenseBudgetAnnual: expenseTotals.totalAnnualBudget || 0,
+        expenseBudgetAnnual: centavosToPesos(expenseTotals.totalAnnualBudget || 0),
 
         // Status based on expense budget health
-        status: expenseVariance >= 0 ? 'favorable' : 'unfavorable',
-        statusText: expenseVariance >= 0 ? 'On Track' : 'Over Budget',
-        statusColor: expenseVariance >= 0 ? '#059669' : '#dc2626',
+        status: expenseVarianceCents >= 0 ? 'favorable' : 'unfavorable',
+        statusText: expenseVarianceCents >= 0 ? 'On Track' : 'Over Budget',
+        statusColor: expenseVarianceCents >= 0 ? '#059669' : '#dc2626',
         
         // Over-budget watch list for tooltip
         overBudgetItems,
         
         // Legacy fields kept for backward compat
-        netBudgetYTD,
-        netActual,
-        netVariance,
+        netBudgetYTD: centavosToPesos(netBudgetYTDCents),
+        netActual: centavosToPesos(netActualCents),
+        netVariance: centavosToPesos(netVarianceCents),
       });
 
     } catch (err) {

--- a/frontend/sams-ui/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/src/hooks/useDashboardData.js
@@ -123,14 +123,17 @@ export const useDashboardData = () => {
   const accountBalances = useMemo(() => {
     const gross = accountBalancesBeforeCredit.total || 0;
     const credit = unitCreditTotalPesos || 0;
-    const netTotal = Math.round(gross - credit);
+    // If balances failed we fall back to zeros — do not subtract HOA credits (avoids headline 0 − credit < 0).
+    const accountsFailed = Boolean(error.accounts);
+    const creditApplied = accountsFailed ? 0 : credit;
+    const netTotal = Math.round(gross - creditApplied);
     return {
       ...accountBalancesBeforeCredit,
       total: netTotal,
       // Explicit HOA aggregate (pesos), not derived — matches HOADuesView.calculateTotalCredit().
-      unitCreditsPesos: credit
+      unitCreditsPesos: accountsFailed ? 0 : credit
     };
-  }, [accountBalancesBeforeCredit, unitCreditTotalPesos]);
+  }, [accountBalancesBeforeCredit, unitCreditTotalPesos, error.accounts]);
 
   // Fetch HOA dues status
   useEffect(() => {

--- a/frontend/sams-ui/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/src/hooks/useDashboardData.js
@@ -28,7 +28,7 @@ export const useDashboardData = () => {
     cash: 0,
     accounts: []
   });
-  /** Sum of owner unit credit balances (pesos) from same hoadues/year payload as HOA card. */
+  /** Same total as HOADuesView.calculateTotalCredit() — sum of unit creditBalance from hoadues/{year} (pesos). */
   const [unitCreditTotalPesos, setUnitCreditTotalPesos] = useState(0);
   
   const [hoaDuesStatus, setHoaDuesStatus] = useState({
@@ -89,21 +89,12 @@ export const useDashboardData = () => {
         const cashBalance = accountsData.cashBalance || 0;
         const totalBalance = bankBalance + cashBalance;
         const accountsList = accountsData.accounts || [];
-        // Gross pesos: sum all active account balances (same ledger as /balances/current).
-        // Matches user expectation: unit credits = gross − net total (HOADuesView sums creditBalance separately).
-        let sumAllCentavos = 0;
-        accountsList.forEach((acc) => {
-          if (acc.active !== false) {
-            sumAllCentavos += acc.balance || 0;
-          }
-        });
-        const sumAllAccountsPesos = Math.round(sumAllCentavos / 100);
-        const grossPesos =
-          accountsList.length > 0 ? sumAllAccountsPesos : Math.round(totalBalance / 100);
 
-        // Structure the data for the dashboard (convert cents to dollars)
+        // Structure the data for the dashboard (convert cents to pesos).
+        // Gross = bank+cash from GET /balances/current. Unit credits = same sum as HOADuesView.calculateTotalCredit()
+        // (aggregated from hoadues/{year} in the HOA dashboard effect below).
         const balanceData = {
-          total: grossPesos,
+          total: Math.round(totalBalance / 100),
           bank: Math.round(bankBalance / 100),
           cash: Math.round(cashBalance / 100),
           accounts: accountsList
@@ -133,12 +124,11 @@ export const useDashboardData = () => {
     const gross = accountBalancesBeforeCredit.total || 0;
     const credit = unitCreditTotalPesos || 0;
     const netTotal = Math.round(gross - credit);
-    // Reconciliation line (issue #96): same as HOA table total credit when net = gross − credit.
-    const unitCreditsPesos = gross - netTotal;
     return {
       ...accountBalancesBeforeCredit,
       total: netTotal,
-      unitCreditsPesos
+      // Explicit HOA aggregate (pesos), not derived — matches HOADuesView.calculateTotalCredit().
+      unitCreditsPesos: credit
     };
   }, [accountBalancesBeforeCredit, unitCreditTotalPesos]);
 

--- a/frontend/sams-ui/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/src/hooks/useDashboardData.js
@@ -88,13 +88,25 @@ export const useDashboardData = () => {
         const bankBalance = accountsData.bankBalance || 0;
         const cashBalance = accountsData.cashBalance || 0;
         const totalBalance = bankBalance + cashBalance;
-        
+        const accountsList = accountsData.accounts || [];
+        // Gross pesos: sum all active account balances (same ledger as /balances/current).
+        // Matches user expectation: unit credits = gross − net total (HOADuesView sums creditBalance separately).
+        let sumAllCentavos = 0;
+        accountsList.forEach((acc) => {
+          if (acc.active !== false) {
+            sumAllCentavos += acc.balance || 0;
+          }
+        });
+        const sumAllAccountsPesos = Math.round(sumAllCentavos / 100);
+        const grossPesos =
+          accountsList.length > 0 ? sumAllAccountsPesos : Math.round(totalBalance / 100);
+
         // Structure the data for the dashboard (convert cents to dollars)
         const balanceData = {
-          total: Math.round(totalBalance / 100),
+          total: grossPesos,
           bank: Math.round(bankBalance / 100),
           cash: Math.round(cashBalance / 100),
-          accounts: accountsData.accounts || []
+          accounts: accountsList
         };
         
         setAccountBalancesBeforeCredit(balanceData);
@@ -120,9 +132,13 @@ export const useDashboardData = () => {
   const accountBalances = useMemo(() => {
     const gross = accountBalancesBeforeCredit.total || 0;
     const credit = unitCreditTotalPesos || 0;
+    const netTotal = Math.round(gross - credit);
+    // Reconciliation line (issue #96): same as HOA table total credit when net = gross − credit.
+    const unitCreditsPesos = gross - netTotal;
     return {
       ...accountBalancesBeforeCredit,
-      total: Math.round(gross - credit)
+      total: netTotal,
+      unitCreditsPesos
     };
   }, [accountBalancesBeforeCredit, unitCreditTotalPesos]);
 

--- a/frontend/sams-ui/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/src/hooks/useDashboardData.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useClient } from '../context/ClientContext';
 import { useHOADues } from '../context/HOADuesContext';
@@ -21,12 +21,15 @@ export const useDashboardData = () => {
   const { selectedClient, menuConfig, isLoadingMenu } = useClient();
   const { exchangeRate, loading: exchangeLoading } = useExchangeRates();
   
-  const [accountBalances, setAccountBalances] = useState({
+  /** Gross bank+cash (pesos, rounded); total is reduced by unit credit in useMemo (#96). */
+  const [accountBalancesBeforeCredit, setAccountBalancesBeforeCredit] = useState({
     total: 0,
     bank: 0,
     cash: 0,
     accounts: []
   });
+  /** Sum of owner unit credit balances (pesos) from same hoadues/year payload as HOA card. */
+  const [unitCreditTotalPesos, setUnitCreditTotalPesos] = useState(0);
   
   const [hoaDuesStatus, setHoaDuesStatus] = useState({
     currentlyDue: 0,
@@ -65,7 +68,7 @@ export const useDashboardData = () => {
     const fetchAccountBalances = async () => {
       if (!selectedClient || !samsUser) {
         // Clear data when no client selected
-        setAccountBalances({
+        setAccountBalancesBeforeCredit({
           total: 0,
           bank: 0,
           cash: 0,
@@ -94,13 +97,13 @@ export const useDashboardData = () => {
           accounts: accountsData.accounts || []
         };
         
-        setAccountBalances(balanceData);
+        setAccountBalancesBeforeCredit(balanceData);
       } catch (err) {
         console.error('Error fetching account balances:', err);
         setError(prev => ({ ...prev, accounts: err.message }));
         
         // Fallback to zero balances on error
-        setAccountBalances({
+        setAccountBalancesBeforeCredit({
           total: 0,
           bank: 0,
           cash: 0,
@@ -114,11 +117,21 @@ export const useDashboardData = () => {
     fetchAccountBalances();
   }, [selectedClient, samsUser]);
 
+  const accountBalances = useMemo(() => {
+    const gross = accountBalancesBeforeCredit.total || 0;
+    const credit = unitCreditTotalPesos || 0;
+    return {
+      ...accountBalancesBeforeCredit,
+      total: Math.round(gross - credit)
+    };
+  }, [accountBalancesBeforeCredit, unitCreditTotalPesos]);
+
   // Fetch HOA dues status
   useEffect(() => {
     const fetchHOADuesStatus = async () => {
       if (!selectedClient || !samsUser) {
         // Clear data when no client selected
+        setUnitCreditTotalPesos(0);
         setHoaDuesStatus({
           currentlyDue: 0,
           currentPaid: 0,
@@ -131,6 +144,7 @@ export const useDashboardData = () => {
       }
       
       try {
+        setUnitCreditTotalPesos(0);
         setLoading(prev => ({ ...prev, dues: true }));
         setError(prev => ({ ...prev, dues: null }));
         
@@ -402,6 +416,9 @@ export const useDashboardData = () => {
             });
         }
         prePaidAmount += totalCreditBalances;
+
+        // Owner credits (pesos) — same sums as futurePayments prepay logic; deduct from Account Balances total (#96)
+        setUnitCreditTotalPesos(totalCreditBalances);
         
         // Calculate currently due (total expected to date through current month)
         const currentlyDue = totalExpectedToDate || 0;
@@ -443,6 +460,7 @@ export const useDashboardData = () => {
         setError(prev => ({ ...prev, dues: err.message || 'Unknown error' }));
         
         // Fallback to zero data on error
+        setUnitCreditTotalPesos(0);
         setHoaDuesStatus({
           currentlyDue: 0,
           currentPaid: 0,

--- a/frontend/sams-ui/src/hooks/useDashboardData.js
+++ b/frontend/sams-ui/src/hooks/useDashboardData.js
@@ -11,6 +11,7 @@ import { getFiscalYear, getCurrentFiscalMonth } from '../utils/fiscalYearUtils';
 import { hasWaterBills } from '../utils/clientFeatures';
 import { getMexicoDate } from '../utils/timezone';
 import { getFirstOwnerLastName } from '../utils/unitContactUtils.js';
+import { totalCreditPesosPositiveFromDuesYearRecord } from '@shared/utils/hoaCreditTotals';
 
 // NO CACHE - Dashboard always fetches fresh data
 // Cache was removed to prevent stale data issues (Dec 2025)
@@ -398,17 +399,11 @@ export const useDashboardData = () => {
         
         // Calculate pre-paid amounts - sum backend credit + future payment values
         let prePaidAmount = 0;
-        let totalCreditBalances = 0;
+        const totalCreditBalances = totalCreditPesosPositiveFromDuesYearRecord(duesDataFromAPI);
         if (duesDataFromAPI && Object.keys(duesDataFromAPI).length > 0) {
           Object.entries(duesDataFromAPI)
-            .filter(([unitId]) => unitId !== 'creditBalances')
-            .forEach(([unitId, unitData]) => {
-              // Sum backend credit balances
-              const creditBalance = unitData?.creditBalance || 0; // From backend
-              if (creditBalance > 0) {
-                totalCreditBalances += creditBalance;
-              }
-              
+            .filter(([unitId]) => unitId !== 'creditBalances' && !unitId.startsWith('creditBalances'))
+            .forEach(([, unitData]) => {
               // Sum backend future payment amounts
               if (unitData?.payments && Array.isArray(unitData.payments)) {
                 for (let fiscalMonth = currentMonth + 1; fiscalMonth <= 12; fiscalMonth++) {

--- a/frontend/sams-ui/src/views/DashboardView.jsx
+++ b/frontend/sams-ui/src/views/DashboardView.jsx
@@ -473,10 +473,18 @@ function DashboardView() {
                       <span>Bank Accounts:</span>
                       <strong>${accountBalances.bank?.toLocaleString() || '0'}</strong>
                     </Typography>
-                    <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
                       <span>Cash Accounts:</span>
                       <strong>${accountBalances.cash?.toLocaleString() || '0'}</strong>
                     </Typography>
+                    {(accountBalances.unitCreditsPesos || 0) > 0 && (
+                      <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                        <span>Unit credits:</span>
+                        <strong style={{ color: '#b45309' }}>
+                          −${Math.round(accountBalances.unitCreditsPesos).toLocaleString()}
+                        </strong>
+                      </Typography>
+                    )}
                   </Box>
                 </>
               )}

--- a/frontend/sams-ui/src/views/DashboardView.jsx
+++ b/frontend/sams-ui/src/views/DashboardView.jsx
@@ -465,10 +465,10 @@ function DashboardView() {
                   <Typography variant="h4" sx={{ color: '#0863bf', fontWeight: 700, mb: 1 }}>
                     ${accountBalances.total?.toLocaleString() || '0'}
                   </Typography>
-                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                    Total Balance
+                  <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+                    Bank + Cash − Credit Balances
                   </Typography>
-                  <Box sx={{ mt: 2 }}>
+                  <Box sx={{ mt: 2, pt: 1, borderTop: '1px solid rgba(0,0,0,0.08)' }}>
                     <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
                       <span>Bank Accounts:</span>
                       <strong>${accountBalances.bank?.toLocaleString() || '0'}</strong>
@@ -479,9 +479,9 @@ function DashboardView() {
                     </Typography>
                     {(accountBalances.unitCreditsPesos || 0) > 0 && (
                       <Typography variant="body2" sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-                        <span>Unit credits:</span>
-                        <strong style={{ color: '#b45309' }}>
-                          −${Math.round(accountBalances.unitCreditsPesos).toLocaleString()}
+                        <span style={{ color: 'rgba(0,0,0,0.6)' }}>Credit Balances</span>
+                        <strong>
+                          ${Math.round(accountBalances.unitCreditsPesos).toLocaleString()}
                         </strong>
                       </Typography>
                     )}

--- a/frontend/sams-ui/src/views/HOADuesView.jsx
+++ b/frontend/sams-ui/src/views/HOADuesView.jsx
@@ -26,6 +26,7 @@ import {
 import { getMexicoDate } from '../utils/timezone';
 import { formatAsMXN } from '../utils/hoaDuesUtils';
 import { centavosToPesos } from '@shared/utils/currencyUtils';
+import { totalCreditPesosFromDuesDataByUnitsList } from '@shared/utils/hoaCreditTotals';
 import debug from '../utils/debug';
 import ContextMenu from '../components/ContextMenu';
 import PaymentDetailsModal from '../components/PaymentDetailsModal';
@@ -590,13 +591,9 @@ function HOADuesView() {
     return units.reduce((total, unit) => total + calculateUnitTotal(unit.unitId), 0);
   };
 
-  // Calculate total credit - Sum backend creditBalance values
-  const calculateTotalCredit = () => {
-    return units.reduce((total, unit) => {
-      const unitData = duesData[unit.unitId];
-      return total + (unitData?.creditBalance || 0);
-    }, 0);
-  };
+  // Total credit footer — shared util (same aggregation as single source in @shared/utils/hoaCreditTotals)
+  const calculateTotalCredit = () =>
+    totalCreditPesosFromDuesDataByUnitsList(duesData || {}, units || []);
 
   // ============================================
   // QUARTERLY DISPLAY FUNCTIONS

--- a/functions/shared/utils/creditBalanceUtils.js
+++ b/functions/shared/utils/creditBalanceUtils.js
@@ -8,27 +8,18 @@
  */
 
 import { getNow } from '../services/DateService.js';
+import { getCreditBalanceCentavos } from './hoaCreditTotals.js';
 
 /**
  * Calculate current credit balance from history entries.
  * This is the ONLY source of truth for credit balance.
- * 
- * ARCHITECTURAL PRINCIPLE: amount field is the single source of truth.
- * - Positive amount = credit added
- * - Negative amount = credit used
- * 
+ * Delegates to {@link getCreditBalanceCentavos} in hoaCreditTotals.js (browser-safe single implementation).
+ *
  * @param {Object} creditDoc - The credit balance document from Firestore
  * @returns {number} Credit balance in centavos
  */
 export function getCreditBalance(creditDoc) {
-  if (!creditDoc?.history || !Array.isArray(creditDoc.history)) {
-    return 0;
-  }
-  
-  return creditDoc.history.reduce((sum, entry) => {
-    const amount = typeof entry.amount === 'number' ? entry.amount : 0;
-    return sum + amount;
-  }, 0);
+  return getCreditBalanceCentavos(creditDoc);
 }
 
 /**

--- a/functions/shared/utils/hoaCreditTotals.js
+++ b/functions/shared/utils/hoaCreditTotals.js
@@ -1,0 +1,71 @@
+/**
+ * HOA credit aggregation — single source for dashboard + HOADuesView + PWA.
+ * Pure functions only (safe for browser bundles; no DateService / firebase-admin).
+ *
+ * @module shared/utils/hoaCreditTotals
+ */
+
+/**
+ * Current credit balance in centavos from one unit's slice of `units/creditBalances` (history journal).
+ * Same algorithm as legacy getCreditBalance in creditBalanceUtils (amount-only rollup).
+ *
+ * @param {Object|null|undefined} creditDoc - Unit entry under creditBalances root doc
+ * @returns {number} Balance in centavos (signed)
+ */
+export function getCreditBalanceCentavos(creditDoc) {
+  if (!creditDoc?.history || !Array.isArray(creditDoc.history)) {
+    return 0;
+  }
+  return creditDoc.history.reduce((sum, entry) => {
+    const amount = typeof entry.amount === 'number' ? entry.amount : 0;
+    return sum + amount;
+  }, 0);
+}
+
+/**
+ * Sum positive unit credits in centavos from full `creditBalances` document data (Firestore).
+ * Aligns with dashboard / pre-pay logic (only credits > 0).
+ *
+ * @param {Record<string, object>} allCreditData - `creditBalances` doc .data()
+ * @param {string[]} unitIds - Real unit ids (caller excludes pseudo-units)
+ * @returns {number}
+ */
+export function totalCreditCentavosPositiveFromCreditBalancesRoot(allCreditData, unitIds) {
+  let total = 0;
+  for (const id of unitIds) {
+    const c = getCreditBalanceCentavos(allCreditData[id] || {});
+    if (c > 0) total += c;
+  }
+  return total;
+}
+
+/**
+ * Sum creditBalance in pesos from HOA year API payload (positive only).
+ * Matches useDashboardData pre-paid / Account Balances deduction aggregation.
+ *
+ * @param {Record<string, { creditBalance?: number }>|null|undefined} duesDataByUnitId
+ * @returns {number}
+ */
+export function totalCreditPesosPositiveFromDuesYearRecord(duesDataByUnitId) {
+  let sum = 0;
+  for (const [unitId, unitData] of Object.entries(duesDataByUnitId || {})) {
+    if (unitId === 'creditBalances' || unitId.startsWith('creditBalances')) continue;
+    const creditBalance = unitData?.creditBalance || 0;
+    if (creditBalance > 0) sum += creditBalance;
+  }
+  return sum;
+}
+
+/**
+ * Footer total credit — same math as HOADuesView.calculateTotalCredit(): sum per visible unit (all signed values, pesos).
+ *
+ * @param {Record<string, { creditBalance?: number }>} duesDataByUnitId
+ * @param {Array<{ unitId: string }>} units
+ * @returns {number}
+ */
+export function totalCreditPesosFromDuesDataByUnitsList(duesDataByUnitId, units) {
+  return units.reduce((total, unit) => {
+    const unitData = duesDataByUnitId[unit.unitId];
+    return total + (unitData?.creditBalance || 0);
+  }, 0);
+}


### PR DESCRIPTION
## Summary

- **#288:** Budget vs Actual API returns amounts in **centavos**; `useBudgetStatus` now converts with `centavosToPesos` so the Budget Status card shows correct pesos.
- **#96:** Account Balances headline total = bank+cash (gross, pesos) minus the same aggregate unit **creditBalance** sum as `HOADuesView.calculateTotalCredit()` from `hoadues/{year}`. Detail row **Credit Balances** shows that amount as a **positive** dollar figure; caption **Bank + Cash − Credit Balances** matches native Financial Health (`HOADashboard.jsx`).
- **PWA:** `sams-ui/mobile-app` dashboard hook/card updated for centavos→pesos, credit aggregation, and matching UI.

## Constraints

- No backend, Firestore writes, or UPC/SoA/reconciliation core changes.

## Testing

- `bash scripts/pre-pr-checks.sh main` — passes Checks 1, 2, 4. Check 3 warns on `navigate('/reports')`; that route is valid via `/:activity` → `ActivityView` in `App.jsx` (static grep false positive).
- Manual production check recommended for Budget + Account cards.

## Related

Closes / addresses GitHub **#288**, **#96**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how key financial totals are computed and displayed on both desktop and PWA dashboards (centavos→pesos conversion and credit deductions), which could affect reported balances if assumptions diverge from backend data shapes. No auth or write-path changes, but miscalculation risk warrants review.
> 
> **Overview**
> **Dashboard financial totals are corrected and normalized across desktop + PWA.** Budget Status now converts Budget-vs-Actual API values from *centavos* to pesos before computing/printing derived metrics.
> 
> **Account Balances headline total is changed to a net figure** (`bank + cash − positive unit credit balances`), with a new “Credit Balances” detail row and caption updates in both `DashboardView` and the PWA `Dashboard`.
> 
> **HOA credit aggregation is centralized** via new shared pure utilities in `functions/shared/utils/hoaCreditTotals.js`, reused by desktop dashboard calculations, `HOADuesView` footer totals, and the PWA hook; PWA also adds a Vite `@shared` alias to import these shared utils.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f056ada8fb83fef23e71ac2f47df22151e4421cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->