### PR TITLE
fix(reconciliation): harden upload parser for BugBot findings

### DIFF
--- a/functions/backend/routes/reconciliations.js
+++ b/functions/backend/routes/reconciliations.js
@@ -25,6 +25,7 @@ import {
 const router = express.Router();
 const MAX_UPLOAD_BYTES = 30 * 1024 * 1024;
 const MAX_MULTIPART_BYTES = (MAX_UPLOAD_BYTES * 2) + (2 * 1024 * 1024); // bank + optional pdf + form overhead
+const MULTIPART_READ_TIMEOUT_MS = 5000;
 const ALLOWED_UPLOAD_FIELDS = new Set(['bankFile', 'statementPdf']);
 
 class UploadParseError extends Error {
@@ -70,6 +71,7 @@ async function parseImportMultipartFromRawBody(req) {
 
   return new Promise((resolve, reject) => {
     let failed = false;
+    let totalFilesSeen = 0;
     const parsedFiles = {
       bankFile: [],
       statementPdf: []
@@ -88,12 +90,19 @@ async function parseImportMultipartFromRawBody(req) {
     const bb = Busboy({
       headers: req.headers,
       limits: {
-        files: 2,
+        // Keep slightly above contract max so unknown third file still triggers 'file' handler.
+        files: 3,
         fileSize: MAX_UPLOAD_BYTES
       }
     });
 
     bb.on('file', (fieldname, file, info) => {
+      totalFilesSeen += 1;
+      if (totalFilesSeen > 2) {
+        file.resume();
+        fail('UPLOAD_TOO_MANY_FILES', 'Too many files provided. Maximum is 2 files.', 'file-count');
+        return;
+      }
       if (!ALLOWED_UPLOAD_FIELDS.has(fieldname)) {
         file.resume();
         fail('UPLOAD_INVALID_FIELD', `Unexpected file field "${fieldname}".`, 'file-field');
@@ -135,6 +144,9 @@ async function parseImportMultipartFromRawBody(req) {
 
     bb.on('error', (error) => {
       fail('UPLOAD_PARSE_FAILED', `Failed to parse multipart upload (${error.message}).`, 'busboy');
+    });
+    bb.on('filesLimit', () => {
+      fail('UPLOAD_TOO_MANY_FILES', 'Too many files provided. Maximum is 2 files.', 'files-limit');
     });
 
     bb.on('finish', () => {
@@ -224,8 +236,16 @@ function readRequestStreamToBuffer(req) {
     let total = 0;
     const chunks = [];
     let done = false;
+    const readTimeout = setTimeout(() => {
+      fail(new UploadParseError(
+        'UPLOAD_PARSE_FAILED',
+        `Timed out waiting for multipart upload payload after ${MULTIPART_READ_TIMEOUT_MS}ms.`,
+        'raw-body-timeout'
+      ));
+    }, MULTIPART_READ_TIMEOUT_MS);
 
     const cleanup = () => {
+      clearTimeout(readTimeout);
       req.removeListener('data', onData);
       req.removeListener('end', onEnd);
       req.removeListener('error', onError);


### PR DESCRIPTION
## Summary
- enforce max-two-file contract when multipart includes extra file parts
- handle Busboy `filesLimit` explicitly with typed `UPLOAD_TOO_MANY_FILES` error
- add timeout to request-stream fallback to avoid hanging when buffered body is unavailable

## Test plan
- [x] `node --check functions/backend/routes/reconciliations.js`
- [ ] BugBot review on this PR
- [ ] Manual dev upload: bank-only and bank+PDF

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the reconciliation import upload parsing path; stricter file-count enforcement and new timeouts could reject some previously-accepted (or slow) uploads and impact imports if edge cases weren’t accounted for.
> 
> **Overview**
> Tightens reconciliation import multipart handling to **consistently enforce the max-2-file contract**, including cases where extra file parts are present (tracks total files seen) and explicitly handles Busboy `filesLimit` with a typed `UPLOAD_TOO_MANY_FILES` error.
> 
> Adds a `MULTIPART_READ_TIMEOUT_MS` timeout when falling back to buffering the request stream (when `req.rawBody` is unavailable) to avoid hanging on incomplete/slow uploads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c81651f724faf53847468ff3b27ac391bde121c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->