### PR TITLE
fix(auth): normalize login eligibility field contract (#266)

### DIFF
--- a/functions/backend/controllers/passkeyController.js
+++ b/functions/backend/controllers/passkeyController.js
@@ -15,6 +15,7 @@ import { webauthnConfig } from '../config/webauthnConfig.js';
 import { getNow } from '../services/DateService.js';
 import { validateInviteToken } from './inviteController.js';
 import { logError } from '../../shared/logger.js';
+import { isFirestoreLoginEligible } from '../utils/userLoginEligibility.js';
 import crypto from 'crypto';
 
 const CHALLENGE_TTL_MINUTES = 5;
@@ -311,6 +312,9 @@ export async function authenticationOptions(req, res) {
       if (!user) {
         return res.status(404).json({ error: 'User not found' });
       }
+      if (!isFirestoreLoginEligible(user)) {
+        return res.status(403).json({ error: 'Login is not enabled for this account.' });
+      }
       const passkeysSnap = await db.collection('users').doc(user.uid).collection('passkeys').get();
       allowCredentials = passkeysSnap.docs.map((d) => ({
         id: d.id,
@@ -403,6 +407,12 @@ export async function authenticationVerify(req, res) {
       return res.status(401).json({ error: 'Verification failed' });
     }
 
+    const userDoc = await db.collection('users').doc(uid).get();
+    const userData = userDoc.exists ? userDoc.data() : {};
+    if (!isFirestoreLoginEligible(userData)) {
+      return res.status(403).json({ error: 'Login is not enabled for this account.' });
+    }
+
     const { newCounter } = verification.authenticationInfo;
     const now = getNow();
 
@@ -412,8 +422,6 @@ export async function authenticationVerify(req, res) {
     });
 
     const customToken = await admin.auth().createCustomToken(uid);
-    const userDoc = await db.collection('users').doc(uid).get();
-    const userData = userDoc.exists ? userDoc.data() : {};
 
     res.json({
       token: customToken,

--- a/functions/backend/controllers/userManagementController.js
+++ b/functions/backend/controllers/userManagementController.js
@@ -11,6 +11,7 @@ import admin from 'firebase-admin';
 import { writeAuditLog } from '../utils/auditLogger.js';
 import { validateClientAccess, sanitizeUserData } from '../utils/securityUtils.js';
 import { isSystemSchedulerAccount } from '../utils/systemSchedulerAccount.js';
+import { isFirestoreLoginEligible } from '../utils/userLoginEligibility.js';
 import { sendPasswordNotification } from '../services/emailService.js';
 import { getNow } from '../services/DateService.js';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
@@ -570,9 +571,8 @@ export async function getUsers(req, res) {
     // Enhance users with Firebase Auth metadata (including lastSignInTime)
     // Note: Contact-only users (canLogin=false) don't have Firebase Auth records - this is expected
     const enhancedUsers = await Promise.all(users.map(async (user) => {
-      // Only fetch Firebase Auth data for users who can login
-      if (user.canLogin === false) {
-        // Contact-only user - no Auth record expected, skip fetch
+      // Skip Auth metadata fetch for ineligible users (no Auth record expected), except system scheduler
+      if (!isFirestoreLoginEligible(user) && !isSystemSchedulerAccount(user.id, user)) {
         return {
           ...user,
           firebaseMetadata: {

--- a/functions/backend/routes/auth.js
+++ b/functions/backend/routes/auth.js
@@ -10,6 +10,7 @@ import { sendPasswordNotification } from '../services/emailService.js';
 import { getNow } from '../services/DateService.js';
 import { isSystemSchedulerAccount } from '../utils/systemSchedulerAccount.js';
 import { generateSecureTempPassword } from '../../shared/utils/tempPassword.js';
+import { isFirestoreLoginEligible } from '../utils/userLoginEligibility.js';
 
 const router = express.Router();
 
@@ -65,7 +66,7 @@ router.post('/reset-password', async (req, res) => {
       });
     }
 
-    if (userData.isActive === false || userData.canLogin === false) {
+    if (userData.isActive === false || !isFirestoreLoginEligible(userData)) {
       return res.status(403).json({ error: 'This account has been deactivated. Please contact your administrator.' });
     }
 

--- a/functions/backend/routes/user.js
+++ b/functions/backend/routes/user.js
@@ -7,6 +7,8 @@ import {
   logSecurityEvent 
 } from '../middleware/clientAuth.js';
 import { sanitizeUserData } from '../utils/securityUtils.js';
+import { isFirestoreLoginEligible } from '../utils/userLoginEligibility.js';
+import { isSystemSchedulerAccount } from '../utils/systemSchedulerAccount.js';
 import { DateService, getNow } from '../services/DateService.js';
 import { logDebug, logInfo, logWarn, logError } from '../../shared/logger.js';
 
@@ -78,6 +80,10 @@ router.get('/profile', authenticateUserWithProfile, async (req, res) => {
       ...userData,
       propertyAccess: userData.propertyAccess ? Object.keys(userData.propertyAccess) : []
     });
+
+    if (!isSystemSchedulerAccount(uid, userData) && !isFirestoreLoginEligible(userData)) {
+      return res.status(403).json({ error: 'This account has been deactivated. Please contact your administrator.' });
+    }
     
     // Ensure user has required fields (include profile and notifications for Manage Profile)
     // Prefer userData.email (Firestore) over token email — token can be stale after email change
@@ -92,6 +98,9 @@ router.get('/profile', authenticateUserWithProfile, async (req, res) => {
       isActive: userData.isActive !== undefined ? userData.isActive : true,
       accountState: userData.accountState || 'active',
       mustChangePassword: userData.mustChangePassword || false,
+      // Raw flags for sanitizeUserData → canonical canLogin in API response
+      canLogin: userData.canLogin,
+      loginEnabled: userData.loginEnabled,
       createdAt: formatDateField(userData.createdAt),
       lastLogin: formatDateField(getNow()),
       profile: userData.profile || {},

--- a/functions/backend/utils/securityUtils.js
+++ b/functions/backend/utils/securityUtils.js
@@ -7,6 +7,7 @@
  */
 
 import { getNow } from '../services/DateService.js';
+import { isFirestoreLoginEligible } from './userLoginEligibility.js';
 
 /**
  * Validate that a user can access a specific client
@@ -174,8 +175,8 @@ export function sanitizeUserData(userData, requestingUser) {
     isActive: userData.isActive,
     lastLoginDate: userData.lastLoginDate,
     firebaseMetadata: userData.firebaseMetadata,
-    // Include new profile fields
-    canLogin: userData.canLogin,
+    // Canonical boolean for UI (bridges legacy loginEnabled when canLogin unset)
+    canLogin: isFirestoreLoginEligible(userData),
     accountState: userData.accountState,
     profile: userData.profile,
     notifications: userData.notifications

--- a/functions/backend/utils/userLoginEligibility.js
+++ b/functions/backend/utils/userLoginEligibility.js
@@ -1,0 +1,21 @@
+/**
+ * Single contract for Firestore-backed login eligibility.
+ *
+ * Canonical field: `canLogin` (boolean). Undefined is treated as "legacy / unset"
+ * and defaults to allowed unless legacy `loginEnabled === false` is present.
+ *
+ * `loginEnabled` is obsolete — read only for backward compatibility when
+ * `canLogin` was never written.
+ */
+
+/**
+ * @param {Record<string, unknown>|null|undefined} userData
+ * @returns {boolean}
+ */
+export function isFirestoreLoginEligible(userData) {
+  if (!userData) return false;
+  if (userData.canLogin === false) return false;
+  if (userData.canLogin === true) return true;
+  if (userData.loginEnabled === false) return false;
+  return true;
+}

--- a/scripts/reconcile-auth-users.js
+++ b/scripts/reconcile-auth-users.js
@@ -15,6 +15,7 @@
 import admin from 'firebase-admin';
 import { createInterface } from 'readline';
 import { generateSecureTempPassword } from '../functions/shared/utils/tempPassword.js';
+import { getNow } from '../functions/backend/services/DateService.js';
 
 // ── CLI Argument Parsing ─────────────────────────────────────────────────────
 
@@ -328,7 +329,7 @@ async function runFix(orphanedUsers) {
   console.log('  For each orphaned user, the script will:');
   console.log('    1. Create a Firebase Auth record with the SAME UID as the Firestore doc');
   console.log('    2. Set the Auth account as DISABLED');
-  console.log('    3. Remove obsolete loginEnabled from the Firestore document (if present)');
+  console.log('    3. Set canLogin=false, remove obsolete loginEnabled (if present)');
   console.log('    4. Add reconciliation metadata to the Firestore document');
   console.log('');
   console.log(`  Target project: ${projectId}`);
@@ -376,9 +377,10 @@ async function runFix(orphanedUsers) {
 
       // Step 2: Update Firestore document (Auth disabled flag is source of truth for login access)
       await db.collection('users').doc(docId).update({
+        canLogin: false,
         loginEnabled: admin.firestore.FieldValue.delete(),
         _reconciled: true,
-        _reconciledAt: new Date().toISOString(),
+        _reconciledAt: getNow().toISOString(),
         _reconciledBy: 'reconcile-auth-users-script',
         _reconciledNote: 'Auth record recreated after backup/restore loss',
       });

--- a/scripts/reconcile-auth-users.js
+++ b/scripts/reconcile-auth-users.js
@@ -197,7 +197,6 @@ async function runAudit() {
         email: email || null,
         displayName: userData.displayName || userData.name || '',
         globalRole: userData.globalRole || '',
-        loginEnabled: userData.loginEnabled,
         propertyAccess: userData.propertyAccess || userData.clientAccess || {},
       });
     } catch (err) {
@@ -247,14 +246,14 @@ function printSummary(result) {
   if (orphanedUsers.length > 0) {
     console.log('ORPHANED USERS (Firestore doc exists, no Firebase Auth record):');
     console.log('┌──────────────────────────────┬──────────────────────────────────────┬────────────────┬──────────────┐');
-    console.log('│ Email                        │ Doc ID (old UID)                     │ Role           │ Login        │');
+    console.log('│ Email                        │ Doc ID (old UID)                     │ Role           │ Auth record  │');
     console.log('├──────────────────────────────┼──────────────────────────────────────┼────────────────┼──────────────┤');
     for (const u of orphanedUsers) {
       const email = padRight(u.email || '(no email)', 28);
       const docId = padRight(u.docId, 36);
       const role = padRight(u.globalRole || '-', 14);
-      const login = padRight(u.loginEnabled === true ? 'enabled' : u.loginEnabled === false ? 'disabled' : 'unset', 12);
-      console.log(`│ ${email} │ ${docId} │ ${role} │ ${login} │`);
+      const authCol = padRight('none', 12);
+      console.log(`│ ${email} │ ${docId} │ ${role} │ ${authCol} │`);
     }
     console.log('└──────────────────────────────┴──────────────────────────────────────┴────────────────┴──────────────┘');
     console.log('');
@@ -329,7 +328,7 @@ async function runFix(orphanedUsers) {
   console.log('  For each orphaned user, the script will:');
   console.log('    1. Create a Firebase Auth record with the SAME UID as the Firestore doc');
   console.log('    2. Set the Auth account as DISABLED');
-  console.log('    3. Set loginEnabled = false in the Firestore document');
+  console.log('    3. Remove obsolete loginEnabled from the Firestore document (if present)');
   console.log('    4. Add reconciliation metadata to the Firestore document');
   console.log('');
   console.log(`  Target project: ${projectId}`);
@@ -375,9 +374,9 @@ async function runFix(orphanedUsers) {
         disabled: true,
       });
 
-      // Step 2: Update Firestore document
+      // Step 2: Update Firestore document (Auth disabled flag is source of truth for login access)
       await db.collection('users').doc(docId).update({
-        loginEnabled: false,
+        loginEnabled: admin.firestore.FieldValue.delete(),
         _reconciled: true,
         _reconciledAt: new Date().toISOString(),
         _reconciledBy: 'reconcile-auth-users-script',


### PR DESCRIPTION
## Summary
- add a shared `isFirestoreLoginEligible()` utility to unify `canLogin` behavior and bridge legacy `loginEnabled` only when `canLogin` is unset
- wire eligibility checks through auth/profile/passkey and user-management sanitize/getUsers flows
- update reconcile-auth-users script to write `canLogin=false`, delete legacy `loginEnabled`, and use `getNow()` timestamps

## Test plan
- [x] `bash scripts/pre-pr-checks.sh main` (frontend gate reports no FE changes)
- [x] `node --check` on modified backend files
- [ ] Manual auth/admin verification in deployment environment

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and account access gating across multiple entry points; incorrect field values or edge cases could inadvertently block logins or password resets for some users.
> 
> **Overview**
> Normalizes the Firestore login-eligibility contract by introducing `isFirestoreLoginEligible()` (canonical `canLogin`, with legacy fallback to `loginEnabled` only when `canLogin` is unset) and using it as the single source of truth.
> 
> Wires this eligibility check into passkey auth (`passkeyController`), password reset (`routes/auth.js`), user profile retrieval (`routes/user.js`), and user management listing/sanitization (`userManagementController`/`securityUtils`) so ineligible accounts are blocked and UI receives a consistent `canLogin` value. Updates `reconcile-auth-users.js` to set `canLogin=false`, delete legacy `loginEnabled`, and use `getNow()` for reconciliation timestamps/output wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e87f38dd7663fa5269d60ad9c5d03a03b849e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->