### PR TITLE
feat(reports): Budget vs Actual YTD vs projected FY-end (#165)

### DIFF
--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.css
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.css
@@ -76,6 +76,18 @@
   color: white;
 }
 
+.budget-actual-mode-label {
+  font-size: 13px;
+  color: #555;
+  margin-right: 4px;
+}
+
+.budget-actual-report-mode-toggle button {
+  font-size: 12px;
+  padding: 6px 10px;
+  white-space: nowrap;
+}
+
 .budget-actual-generate-button {
   padding: 8px 16px;
   border-radius: 4px;

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -178,6 +178,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
         await reportService.exportBudgetActualPdfFromHtml(selectedClient.id, {
           fiscalYear,
           language,
+          reportMode,
           html: htmlPreview,
           meta: reportData?.meta || {}
         });
@@ -188,7 +189,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
         setDownloadingPdf(false);
       }
     },
-    [selectedClient, language, fiscalYear, htmlPreview, reportData]
+    [selectedClient, language, fiscalYear, htmlPreview, reportData, reportMode]
   );
 
   const handleDownloadCsv = useCallback(

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -175,12 +175,12 @@ function BudgetActualTab({ zoom = 1.0 }) {
 
       setDownloadingPdf(true);
       try {
+        // PDF is rendered server-side from reportMode (do not send preview HTML — it can
+        // lag behind the toggle and produce a projected filename with YTD content).
         await reportService.exportBudgetActualPdfFromHtml(selectedClient.id, {
           fiscalYear,
           language,
-          reportMode,
-          html: htmlPreview,
-          meta: reportData?.meta || {}
+          reportMode
         });
       } catch (err) {
         console.error('PDF download failed:', err);

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -79,6 +79,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
 
   const [fiscalYear, setFiscalYear] = useState(null);
   const [language, setLanguage] = useState('english');
+  const [reportMode, setReportMode] = useState('ytd');
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -116,7 +117,8 @@ function BudgetActualTab({ zoom = 1.0 }) {
       console.log('[BudgetActual] handleGenerate called', { 
         selectedClient: selectedClient?.id, 
         fiscalYear, 
-        language 
+        language,
+        reportMode
       });
 
       if (!selectedClient || !fiscalYear) {
@@ -132,7 +134,8 @@ function BudgetActualTab({ zoom = 1.0 }) {
         const html = await reportService.getBudgetActualHtml(
           selectedClient.id,
           fiscalYear,
-          language
+          language,
+          reportMode
         );
         console.log('[BudgetActual] HTML fetched, length:', html?.length);
 
@@ -141,7 +144,8 @@ function BudgetActualTab({ zoom = 1.0 }) {
         const data = await reportService.getBudgetActualData(
           selectedClient.id,
           fiscalYear,
-          language
+          language,
+          reportMode
         );
         console.log('[BudgetActual] Data fetched');
 
@@ -156,7 +160,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
         setLoading(false);
       }
     },
-    [selectedClient, language, fiscalYear]
+    [selectedClient, language, fiscalYear, reportMode]
   );
 
   const handleDownloadPdf = useCallback(
@@ -201,7 +205,8 @@ function BudgetActualTab({ zoom = 1.0 }) {
       try {
         await reportService.exportBudgetActualCsv(selectedClient.id, {
           fiscalYear,
-          language
+          language,
+          reportMode
         });
       } catch (err) {
         console.error('CSV download failed:', err);
@@ -210,7 +215,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
         setDownloadingCsv(false);
       }
     },
-    [selectedClient, language, fiscalYear]
+    [selectedClient, language, fiscalYear, reportMode]
   );
 
   const handleRetry = useCallback(() => {
@@ -234,7 +239,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
       return;
     }
     handleGenerate();
-  }, [handleGenerate, selectedClient, fiscalYear, language]);
+  }, [handleGenerate, selectedClient, fiscalYear, language, reportMode]);
 
   if (!selectedClient) {
     return (
@@ -284,6 +289,32 @@ function BudgetActualTab({ zoom = 1.0 }) {
               onClick={() => setLanguage('spanish')}
             >
               ES
+            </button>
+          </div>
+        </div>
+
+        <div className="control-group">
+          <span className="budget-actual-mode-label" id="budget-actual-mode-label">
+            Variance:
+          </span>
+          <div
+            className="language-toggle budget-actual-report-mode-toggle"
+            role="group"
+            aria-labelledby="budget-actual-mode-label"
+          >
+            <button
+              type="button"
+              className={reportMode === 'ytd' ? 'active' : ''}
+              onClick={() => setReportMode('ytd')}
+            >
+              YTD
+            </button>
+            <button
+              type="button"
+              className={reportMode === 'projected' ? 'active' : ''}
+              onClick={() => setReportMode('projected')}
+            >
+              Projected FY-End
             </button>
           </div>
         </div>

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -117,15 +117,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
         event.preventDefault();
       }
 
-      console.log('[BudgetActual] handleGenerate called', { 
-        selectedClient: selectedClient?.id, 
-        fiscalYear, 
-        language,
-        reportMode
-      });
-
       if (!selectedClient || !fiscalYear) {
-        console.log('[BudgetActual] Early return - missing client or fiscal year');
         return;
       }
 
@@ -134,7 +126,6 @@ function BudgetActualTab({ zoom = 1.0 }) {
       setLoading(true);
       setError(null);
 
-      console.log('[BudgetActual] Fetching HTML...');
       try {
         const html = await reportService.getBudgetActualHtml(
           selectedClient.id,
@@ -142,51 +133,22 @@ function BudgetActualTab({ zoom = 1.0 }) {
           language,
           reportMode
         );
-        console.log('[BudgetActual] HTML fetched, length:', html?.length);
 
         // Also fetch data for potential CSV export
-        console.log('[BudgetActual] Fetching data...');
         const data = await reportService.getBudgetActualData(
           selectedClient.id,
           fiscalYear,
           language,
           reportMode
         );
-        console.log('[BudgetActual] Data fetched', {
-          requestedReportMode: reportMode,
-          returnedReportMode: data?.reportInfo?.reportMode,
-          reportId: data?.reportInfo?.reportId,
-          firstIncomeRow: data?.income?.categories?.[0]
-            ? {
-                name: data.income.categories[0].name,
-                annualBudget: data.income.categories[0].annualBudget,
-                ytdBudget: data.income.categories[0].ytdBudget,
-                ytdActual: data.income.categories[0].ytdActual,
-                variance: data.income.categories[0].variance,
-                variancePercent: data.income.categories[0].variancePercent
-              }
-            : null,
-          firstExpenseRow: data?.expenses?.categories?.[0]
-            ? {
-                name: data.expenses.categories[0].name,
-                annualBudget: data.expenses.categories[0].annualBudget,
-                ytdBudget: data.expenses.categories[0].ytdBudget,
-                ytdActual: data.expenses.categories[0].ytdActual,
-                variance: data.expenses.categories[0].variance,
-                variancePercent: data.expenses.categories[0].variancePercent
-              }
-            : null
-        });
 
         if (seq !== budgetActualGenerateSeq.current) {
-          console.log('[BudgetActual] Discarding stale generate result (seq mismatch)');
           return;
         }
 
         setReportData(data);
         setHtmlPreview(html);
         setHasGenerated(true);
-        console.log('[BudgetActual] State updated, report ready');
       } catch (err) {
         console.error('[BudgetActual] Generation error:', err);
         if (seq === budgetActualGenerateSeq.current) {

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -244,6 +244,10 @@ function BudgetActualTab({ zoom = 1.0 }) {
   const isGenerateDisabled = !fiscalYear || loading;
 
   const hasReport = !!reportData && !!htmlPreview;
+  const previewFrameKey = useMemo(() => {
+    const reportId = reportData?.reportInfo?.reportId || 'pending';
+    return `${reportMode}-${reportId}`;
+  }, [reportData, reportMode]);
   const isPdfDisabled = !hasReport || loading || downloadingPdf;
   const isCsvDisabled = !hasReport || loading || downloadingCsv;
   const isPrintDisabled = !hasReport || loading;
@@ -439,6 +443,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
         {!loading && !error && hasGenerated && htmlPreview && (
           <div className="budget-actual-preview-frame-container">
             <iframe
+              key={previewFrameKey}
               title="Budget vs Actual Preview"
               srcDoc={htmlPreview}
               className="budget-actual-preview-frame"

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -79,7 +79,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
 
   const [fiscalYear, setFiscalYear] = useState(null);
   const [language, setLanguage] = useState('english');
-  const [reportMode, setReportMode] = useState('ytd');
+  const [reportMode, setReportMode] = useState('projected');
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -152,7 +152,31 @@ function BudgetActualTab({ zoom = 1.0 }) {
           language,
           reportMode
         );
-        console.log('[BudgetActual] Data fetched');
+        console.log('[BudgetActual] Data fetched', {
+          requestedReportMode: reportMode,
+          returnedReportMode: data?.reportInfo?.reportMode,
+          reportId: data?.reportInfo?.reportId,
+          firstIncomeRow: data?.income?.categories?.[0]
+            ? {
+                name: data.income.categories[0].name,
+                annualBudget: data.income.categories[0].annualBudget,
+                ytdBudget: data.income.categories[0].ytdBudget,
+                ytdActual: data.income.categories[0].ytdActual,
+                variance: data.income.categories[0].variance,
+                variancePercent: data.income.categories[0].variancePercent
+              }
+            : null,
+          firstExpenseRow: data?.expenses?.categories?.[0]
+            ? {
+                name: data.expenses.categories[0].name,
+                annualBudget: data.expenses.categories[0].annualBudget,
+                ytdBudget: data.expenses.categories[0].ytdBudget,
+                ytdActual: data.expenses.categories[0].ytdActual,
+                variance: data.expenses.categories[0].variance,
+                variancePercent: data.expenses.categories[0].variancePercent
+              }
+            : null
+        });
 
         if (seq !== budgetActualGenerateSeq.current) {
           console.log('[BudgetActual] Discarding stale generate result (seq mismatch)');

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { useClient } from '../../context/ClientContext';
 import { useAuth } from '../../context/AuthContext';
 import { getFiscalYear, getFiscalYearLabel } from '../../utils/fiscalYearUtils';
@@ -89,6 +89,9 @@ function BudgetActualTab({ zoom = 1.0 }) {
   const [downloadingPdf, setDownloadingPdf] = useState(false);
   const [downloadingCsv, setDownloadingCsv] = useState(false);
 
+  /** Suppress stale preview when multiple generates overlap (Strict Mode, rapid YTD ↔ Projected). */
+  const budgetActualGenerateSeq = useRef(0);
+
   // Initialize language and fiscal year when client or user changes
   useEffect(() => {
     if (!selectedClient) {
@@ -126,6 +129,8 @@ function BudgetActualTab({ zoom = 1.0 }) {
         return;
       }
 
+      const seq = ++budgetActualGenerateSeq.current;
+
       setLoading(true);
       setError(null);
 
@@ -149,15 +154,24 @@ function BudgetActualTab({ zoom = 1.0 }) {
         );
         console.log('[BudgetActual] Data fetched');
 
+        if (seq !== budgetActualGenerateSeq.current) {
+          console.log('[BudgetActual] Discarding stale generate result (seq mismatch)');
+          return;
+        }
+
         setReportData(data);
         setHtmlPreview(html);
         setHasGenerated(true);
         console.log('[BudgetActual] State updated, report ready');
       } catch (err) {
         console.error('[BudgetActual] Generation error:', err);
-        setError('Failed to generate report. Please try again.');
+        if (seq === budgetActualGenerateSeq.current) {
+          setError('Failed to generate report. Please try again.');
+        }
       } finally {
-        setLoading(false);
+        if (seq === budgetActualGenerateSeq.current) {
+          setLoading(false);
+        }
       }
     },
     [selectedClient, language, fiscalYear, reportMode]

--- a/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
+++ b/frontend/sams-ui/src/components/reports/BudgetActualTab.jsx
@@ -79,7 +79,7 @@ function BudgetActualTab({ zoom = 1.0 }) {
 
   const [fiscalYear, setFiscalYear] = useState(null);
   const [language, setLanguage] = useState('english');
-  const [reportMode, setReportMode] = useState('projected');
+  const [reportMode, setReportMode] = useState('ytd');
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);

--- a/frontend/sams-ui/src/hooks/useBudgetStatus.js
+++ b/frontend/sams-ui/src/hooks/useBudgetStatus.js
@@ -47,7 +47,13 @@ export function useBudgetStatus() {
       // Variance in BvA is (budget - actual), so negative = over budget
       const expenseCategories = budgetData.expenses?.categories || [];
       const overBudgetItems = expenseCategories
-        .filter(item => item.ytdBudget > 0 && item.variance < 0)
+        .filter(
+          item =>
+            item.ytdBudget > 0 &&
+            item.variance != null &&
+            !Number.isNaN(item.variance) &&
+            item.variance < 0
+        )
         .map(item => ({
           category: item.name,
           overAmount: centavosToPesos(Math.abs(item.variance)),

--- a/frontend/sams-ui/src/services/reportService.js
+++ b/frontend/sams-ui/src/services/reportService.js
@@ -11,6 +11,16 @@ class ReportService {
   constructor() {
     // Unified base URL (no /api suffix) - see config/index.js
     this.baseUrl = config.api.baseUrl;
+    this.budgetActualCacheBustSeq = 0;
+  }
+
+  normalizeBudgetActualReportMode(reportMode) {
+    return reportMode === 'projected' ? 'projected' : 'ytd';
+  }
+
+  createBudgetActualCacheBustToken() {
+    this.budgetActualCacheBustSeq += 1;
+    return `${this.budgetActualCacheBustSeq}-${Math.floor(performance.now())}`;
   }
 
   /**
@@ -370,21 +380,23 @@ class ReportService {
    */
   async getBudgetActualData(clientId, fiscalYear = null, language = 'english', reportMode = 'ytd') {
     const headers = await this.getAuthHeaders();
+    const normalizedReportMode = this.normalizeBudgetActualReportMode(reportMode);
 
     const params = new URLSearchParams();
     params.append('language', language);
     if (fiscalYear) {
       params.append('fiscalYear', String(fiscalYear));
     }
-    if (reportMode === 'projected') {
-      params.append('reportMode', 'projected');
-    }
+    // Always send reportMode explicitly to avoid silent fallback to server default.
+    params.append('reportMode', normalizedReportMode);
+    params.append('_cb', this.createBudgetActualCacheBustToken());
 
     const response = await fetch(
       `${this.baseUrl}/reports/${clientId}/budget-actual/data?${params.toString()}`,
       {
         method: 'GET',
-        headers
+        headers,
+        cache: 'no-store'
       }
     );
 
@@ -408,21 +420,23 @@ class ReportService {
    */
   async getBudgetActualHtml(clientId, fiscalYear = null, language = 'english', reportMode = 'ytd') {
     const headers = await this.getAuthHeaders();
+    const normalizedReportMode = this.normalizeBudgetActualReportMode(reportMode);
 
     const params = new URLSearchParams();
     params.append('language', language);
     if (fiscalYear) {
       params.append('fiscalYear', String(fiscalYear));
     }
-    if (reportMode === 'projected') {
-      params.append('reportMode', 'projected');
-    }
+    // Always send reportMode explicitly to avoid silent fallback to server default.
+    params.append('reportMode', normalizedReportMode);
+    params.append('_cb', this.createBudgetActualCacheBustToken());
 
     const response = await fetch(
       `${this.baseUrl}/reports/${clientId}/budget-actual/html?${params.toString()}`,
       {
         method: 'GET',
-        headers
+        headers,
+        cache: 'no-store'
       }
     );
 

--- a/frontend/sams-ui/src/services/reportService.js
+++ b/frontend/sams-ui/src/services/reportService.js
@@ -392,10 +392,6 @@ class ReportService {
     params.append('_cb', this.createBudgetActualCacheBustToken());
 
     const requestUrl = `${this.baseUrl}/reports/${clientId}/budget-actual/data?${params.toString()}`;
-    console.log('[ReportService] GET BudgetActual data', {
-      path: requestUrl,
-      reportMode: normalizedReportMode
-    });
 
     const response = await fetch(
       requestUrl,
@@ -410,13 +406,6 @@ class ReportService {
     if (!response.ok || json.success === false) {
       throw new Error(json.error || 'Failed to fetch budget vs actual data');
     }
-
-    console.log('[ReportService] BudgetActual data response summary', {
-      returnedReportMode: json?.data?.reportInfo?.reportMode,
-      reportId: json?.data?.reportInfo?.reportId,
-      incomeCount: json?.data?.income?.categories?.length || 0,
-      expenseCount: json?.data?.expenses?.categories?.length || 0
-    });
 
     // Return the data object (income, expenses, specialAssessments, etc.)
     return json.data;
@@ -445,10 +434,6 @@ class ReportService {
     params.append('_cb', this.createBudgetActualCacheBustToken());
 
     const requestUrl = `${this.baseUrl}/reports/${clientId}/budget-actual/html?${params.toString()}`;
-    console.log('[ReportService] GET BudgetActual html', {
-      path: requestUrl,
-      reportMode: normalizedReportMode
-    });
 
     const response = await fetch(
       requestUrl,
@@ -467,12 +452,6 @@ class ReportService {
     }
 
     const html = await response.text();
-    console.log('[ReportService] BudgetActual html response markers', {
-      reportMode: normalizedReportMode,
-      hasProjectedBasisText: html.includes('Projected year-end'),
-      hasYtdBudgetHeader: html.includes('YTD BUDGET'),
-      hasProjectedVarianceHeader: html.includes('PROJECTED VARIANCE')
-    });
     return html;
   }
 

--- a/frontend/sams-ui/src/services/reportService.js
+++ b/frontend/sams-ui/src/services/reportService.js
@@ -391,8 +391,14 @@ class ReportService {
     params.append('reportMode', normalizedReportMode);
     params.append('_cb', this.createBudgetActualCacheBustToken());
 
+    const requestUrl = `${this.baseUrl}/reports/${clientId}/budget-actual/data?${params.toString()}`;
+    console.log('[ReportService] GET BudgetActual data', {
+      path: requestUrl,
+      reportMode: normalizedReportMode
+    });
+
     const response = await fetch(
-      `${this.baseUrl}/reports/${clientId}/budget-actual/data?${params.toString()}`,
+      requestUrl,
       {
         method: 'GET',
         headers,
@@ -404,6 +410,13 @@ class ReportService {
     if (!response.ok || json.success === false) {
       throw new Error(json.error || 'Failed to fetch budget vs actual data');
     }
+
+    console.log('[ReportService] BudgetActual data response summary', {
+      returnedReportMode: json?.data?.reportInfo?.reportMode,
+      reportId: json?.data?.reportInfo?.reportId,
+      incomeCount: json?.data?.income?.categories?.length || 0,
+      expenseCount: json?.data?.expenses?.categories?.length || 0
+    });
 
     // Return the data object (income, expenses, specialAssessments, etc.)
     return json.data;
@@ -431,8 +444,14 @@ class ReportService {
     params.append('reportMode', normalizedReportMode);
     params.append('_cb', this.createBudgetActualCacheBustToken());
 
+    const requestUrl = `${this.baseUrl}/reports/${clientId}/budget-actual/html?${params.toString()}`;
+    console.log('[ReportService] GET BudgetActual html', {
+      path: requestUrl,
+      reportMode: normalizedReportMode
+    });
+
     const response = await fetch(
-      `${this.baseUrl}/reports/${clientId}/budget-actual/html?${params.toString()}`,
+      requestUrl,
       {
         method: 'GET',
         headers,
@@ -448,6 +467,12 @@ class ReportService {
     }
 
     const html = await response.text();
+    console.log('[ReportService] BudgetActual html response markers', {
+      reportMode: normalizedReportMode,
+      hasProjectedBasisText: html.includes('Projected year-end'),
+      hasYtdBudgetHeader: html.includes('YTD BUDGET'),
+      hasProjectedVarianceHeader: html.includes('PROJECTED VARIANCE')
+    });
     return html;
   }
 

--- a/frontend/sams-ui/src/services/reportService.js
+++ b/frontend/sams-ui/src/services/reportService.js
@@ -445,9 +445,8 @@ class ReportService {
    * @param {object} params
    * @param {number|null} params.fiscalYear
    * @param {string} params.language
-   * @param {string} params.html - Complete HTML document
    * @param {'ytd'|'projected'} [params.reportMode='ytd']
-   * @param {object} [params.meta] - Optional footer metadata
+   * @param {object} [params.meta] - Ignored for PDF; server regenerates HTML and footer meta from reportMode.
    */
   async exportBudgetActualPdfFromHtml(clientId, params) {
     const headers = await this.getAuthHeaders();
@@ -463,9 +462,7 @@ class ReportService {
         body: JSON.stringify({
           fiscalYear: params.fiscalYear,
           language: params.language || 'english',
-          reportMode: params.reportMode === 'projected' ? 'projected' : 'ytd',
-          html: params.html,
-          meta: params.meta || {}
+          reportMode: params.reportMode === 'projected' ? 'projected' : 'ytd'
         })
       }
     );

--- a/frontend/sams-ui/src/services/reportService.js
+++ b/frontend/sams-ui/src/services/reportService.js
@@ -365,14 +365,18 @@ class ReportService {
    * @param {string} clientId
    * @param {number|null} fiscalYear - Optional fiscal year (e.g., 2025)
    * @param {string} language - 'english' or 'spanish'
+   * @param {'ytd'|'projected'} [reportMode='ytd'] - BUDGET-PROJ-1 variance basis
    */
-  async getBudgetActualData(clientId, fiscalYear = null, language = 'english') {
+  async getBudgetActualData(clientId, fiscalYear = null, language = 'english', reportMode = 'ytd') {
     const headers = await this.getAuthHeaders();
 
     const params = new URLSearchParams();
     params.append('language', language);
     if (fiscalYear) {
       params.append('fiscalYear', String(fiscalYear));
+    }
+    if (reportMode === 'projected') {
+      params.append('reportMode', 'projected');
     }
 
     const response = await fetch(
@@ -399,14 +403,18 @@ class ReportService {
    * @param {string} clientId
    * @param {number|null} fiscalYear - Optional fiscal year
    * @param {string} language - 'english' or 'spanish'
+   * @param {'ytd'|'projected'} [reportMode='ytd']
    */
-  async getBudgetActualHtml(clientId, fiscalYear = null, language = 'english') {
+  async getBudgetActualHtml(clientId, fiscalYear = null, language = 'english', reportMode = 'ytd') {
     const headers = await this.getAuthHeaders();
 
     const params = new URLSearchParams();
     params.append('language', language);
     if (fiscalYear) {
       params.append('fiscalYear', String(fiscalYear));
+    }
+    if (reportMode === 'projected') {
+      params.append('reportMode', 'projected');
     }
 
     const response = await fetch(
@@ -503,7 +511,8 @@ class ReportService {
         headers,
         body: JSON.stringify({
           fiscalYear: params.fiscalYear,
-          language: params.language || 'english'
+          language: params.language || 'english',
+          reportMode: params.reportMode === 'projected' ? 'projected' : 'ytd'
         })
       }
     );
@@ -520,7 +529,8 @@ class ReportService {
     const a = document.createElement('a');
     a.href = url;
     const yearPart = params.fiscalYear || 'current';
-    a.download = `budget-actual-${clientId}-${yearPart}.csv`;
+    const modePart = params.reportMode === 'projected' ? '-projected' : '';
+    a.download = `budget-actual-${clientId}-${yearPart}${modePart}.csv`;
     a.click();
     window.URL.revokeObjectURL(url);
   }

--- a/frontend/sams-ui/src/services/reportService.js
+++ b/frontend/sams-ui/src/services/reportService.js
@@ -445,6 +445,7 @@ class ReportService {
    * @param {number|null} params.fiscalYear
    * @param {string} params.language
    * @param {string} params.html - Complete HTML document
+   * @param {'ytd'|'projected'} [params.reportMode='ytd']
    * @param {object} [params.meta] - Optional footer metadata
    */
   async exportBudgetActualPdfFromHtml(clientId, params) {
@@ -461,6 +462,7 @@ class ReportService {
         body: JSON.stringify({
           fiscalYear: params.fiscalYear,
           language: params.language || 'english',
+          reportMode: params.reportMode === 'projected' ? 'projected' : 'ytd',
           html: params.html,
           meta: params.meta || {}
         })

--- a/frontend/sams-ui/src/services/reportService.js
+++ b/frontend/sams-ui/src/services/reportService.js
@@ -5,6 +5,7 @@
 
 import { getAuthInstance } from '../firebaseClient';
 import { config } from '../config/index.js';
+import { getMexicoDateString, formatDateInMexico } from '../utils/timezone';
 
 class ReportService {
   constructor() {
@@ -717,7 +718,7 @@ class ReportService {
     const url = window.URL.createObjectURL(blob);
 
     // Generate meaningful filename
-    const dateStr = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+    const dateStr = getMexicoDateString();
     const clientName = params.clientName || clientId;
     
     // Build filename from filter summary
@@ -729,8 +730,8 @@ class ReportService {
       // Add date range to filename
       if (dateRange && dateRange !== 'all') {
         if (typeof dateRange === 'object' && dateRange.startDate && dateRange.endDate) {
-          const start = new Date(dateRange.startDate).toISOString().split('T')[0];
-          const end = new Date(dateRange.endDate).toISOString().split('T')[0];
+          const start = formatDateInMexico(dateRange.startDate) || '';
+          const end = formatDateInMexico(dateRange.endDate) || '';
           filenameParts.push(`${start}_to_${end}`);
         } else {
           filenameParts.push(String(dateRange));

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -15,6 +15,7 @@ import { generateStatementData } from '../services/statementHtmlService.js';
 import { generatePdf } from '../services/pdfService.js';
 import { getBudgetActualData } from '../services/budgetActualDataService.js';
 import { generateBudgetActualHtml } from '../services/budgetActualHtmlService.js';
+import { generateBudgetActualText } from '../services/budgetActualTextService.js';
 import { generateBudgetReportHtml } from '../services/budgetReportHtmlService.js';
 import { 
   generateWaterConsumptionReportHtml,
@@ -1017,6 +1018,48 @@ router.get('/budget-actual/html', authenticateUserWithProfile, async (req, res) 
       success: false, 
       error: error.message,
       details: error.stack 
+    });
+  }
+});
+
+/**
+ * Get Budget vs Actual report as plain text (tables)
+ * GET /api/clients/:clientId/reports/budget-actual/text
+ * Query params: fiscalYear?, reportMode? (ytd|projected)
+ */
+router.get('/budget-actual/text', authenticateUserWithProfile, async (req, res) => {
+  try {
+    const clientId = req.originalParams?.clientId || req.params.clientId;
+    const fiscalYear = req.query.fiscalYear ? parseInt(req.query.fiscalYear) : null;
+    const reportMode = parseBudgetActualReportMode(req.query.reportMode);
+    const user = req.user;
+
+    if (!clientId) {
+      return res.status(400).json({
+        success: false,
+        error: 'Client ID is required'
+      });
+    }
+
+    const propertyAccess = user.getPropertyAccess(clientId);
+    if (!propertyAccess) {
+      return res.status(403).json({
+        success: false,
+        error: 'Access denied to this client'
+      });
+    }
+
+    const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
+    const textOutput = generateBudgetActualText(data);
+
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.send(textOutput);
+  } catch (error) {
+    logError('Error generating budget vs actual text:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message,
+      details: error.stack
     });
   }
 });

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -1043,6 +1043,7 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
 
     const format = (req.query.format || bodyFormat || 'pdf').toLowerCase();
     const reportMode = parseBudgetActualReportMode(bodyReportMode);
+    const budgetActualFileSuffix = reportMode === 'projected' ? '-projected' : '';
     const user = req.user;
 
     if (!clientId) {
@@ -1168,7 +1169,7 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
       const csvContent = csvLines.join('\r\n');
 
       const safeClientId = clientId || 'client';
-      const fileName = `budget-actual_${safeClientId}_${fiscalYear || 'current'}.csv`;
+      const fileName = `budget-actual_${safeClientId}_${fiscalYear || 'current'}${budgetActualFileSuffix}.csv`;
 
       res.setHeader('Content-Type', 'text/csv; charset=utf-8');
       res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
@@ -1204,7 +1205,7 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
     });
 
     const safeClientId = clientId || 'client';
-    const fileName = `budget-actual_${safeClientId}_${fiscalYear || 'current'}.pdf`;
+    const fileName = `budget-actual_${safeClientId}_${fiscalYear || 'current'}${budgetActualFileSuffix}.pdf`;
 
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -1068,7 +1068,7 @@ router.get('/budget-actual/text', authenticateUserWithProfile, async (req, res) 
  * Export Budget vs Actual report
  * POST /api/clients/:clientId/reports/budget-actual/export
  * Query param: format=pdf|csv
- * Body: { fiscalYear, language, reportMode?, html?, meta? }
+ * Body: { fiscalYear, language, reportMode? } — PDF HTML is always regenerated server-side (reportMode authoritative).
  *
  * Returns PDF or CSV export of the report
  */
@@ -1079,8 +1079,6 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
       fiscalYear = null,
       language = 'english',
       reportMode: bodyReportMode,
-      html,
-      meta = {},
       format: bodyFormat
     } = req.body || {};
 
@@ -1234,15 +1232,14 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
       });
     }
 
-    let htmlToConvert = html;
-    let metaToUse = meta;
-
-    if (!htmlToConvert) {
-      const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
-      const result = generateBudgetActualHtml(data, { language });
-      htmlToConvert = result.html;
-      metaToUse = result.meta;
-    }
+    // Always build PDF HTML from server data for this reportMode. Client-supplied
+    // `html` is ignored — it can be stale (e.g. user toggled YTD ↔ Projected before
+    // the preview fetch finished), which produced PDFs labeled projected but showing YTD.
+    const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
+    const { html: htmlToConvert, meta: metaFromGen } = generateBudgetActualHtml(data, {
+      language
+    });
+    const metaToUse = metaFromGen;
 
     // Convert HTML to PDF
     const pdfBuffer = await generatePdf(htmlToConvert, {

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -1120,16 +1120,26 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
     if (format === 'csv') {
       const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
 
-      // Same columns for ytd and projected: variance columns reflect reportMode from getBudgetActualData.
-      const header = [
-        'Category Name',
-        'Type',
-        'Annual Budget',
-        'YTD Budget',
-        'YTD Actual',
-        'Variance ($)',
-        'Variance (%)'
-      ];
+      const isProjected = reportMode === 'projected';
+      const header = isProjected
+        ? [
+            'Category Name',
+            'Type',
+            'Annual Budget',
+            'YTD Budget (Reference)',
+            'YTD Actual (Reference)',
+            'Projected Variance ($)',
+            'Projected Variance (%)'
+          ]
+        : [
+            'Category Name',
+            'Type',
+            'Annual Budget',
+            'YTD Budget',
+            'YTD Actual',
+            'Variance ($)',
+            'Variance (%)'
+          ];
       const rows = [];
 
       data.income.categories.forEach(cat => {

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -15,7 +15,6 @@ import { generateStatementData } from '../services/statementHtmlService.js';
 import { generatePdf } from '../services/pdfService.js';
 import { getBudgetActualData } from '../services/budgetActualDataService.js';
 import { generateBudgetActualHtml } from '../services/budgetActualHtmlService.js';
-import { generateBudgetActualText } from '../services/budgetActualTextService.js';
 import { generateBudgetReportHtml } from '../services/budgetReportHtmlService.js';
 import { 
   generateWaterConsumptionReportHtml,
@@ -29,6 +28,11 @@ import axios from 'axios';
 import creditAutoPayReportRoutes from './creditAutoPayReportRoutes.js';
 import { logInfo, logDebug, logWarn, logError } from '../../shared/logger.js';
 import { centavosToPesos, roundPesos } from '../../shared/utils/currencyUtils.js';
+
+/** BUDGET-PROJ-1: YTD vs projected FY-end variance basis */
+function parseBudgetActualReportMode(value) {
+  return value === 'projected' ? 'projected' : 'ytd';
+}
 
 // Create date service for formatting API responses
 const dateService = new DateService({ timezone: 'America/Cancun' });
@@ -925,13 +929,15 @@ router.get('/statement/pdf-download', async (req, res) => {
  * Query params:
  *   - fiscalYear (optional): Fiscal year (defaults to current)
  *   - language (optional): 'english' or 'spanish' (defaults to 'english')
- * 
+ *   - reportMode (optional): 'ytd' | 'projected' (defaults to 'ytd')
+ *
  * Returns comprehensive data object with budget vs actual data
  */
 router.get('/budget-actual/data', authenticateUserWithProfile, async (req, res) => {
   try {
     const clientId = req.originalParams?.clientId || req.params.clientId;
     const fiscalYear = req.query.fiscalYear ? parseInt(req.query.fiscalYear) : null;
+    const reportMode = parseBudgetActualReportMode(req.query.reportMode);
     const user = req.user;
     
     if (!clientId) {
@@ -950,8 +956,7 @@ router.get('/budget-actual/data', authenticateUserWithProfile, async (req, res) 
       });
     }
 
-    // Get budget vs actual data
-    const data = await getBudgetActualData(clientId, fiscalYear, user);
+    const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
     
     res.json({ success: true, data });
   } catch (error) {
@@ -970,7 +975,8 @@ router.get('/budget-actual/data', authenticateUserWithProfile, async (req, res) 
  * Query params:
  *   - fiscalYear (optional): Fiscal year (defaults to current)
  *   - language (optional): 'english' or 'spanish' (defaults to 'english')
- * 
+ *   - reportMode (optional): 'ytd' | 'projected' (defaults to 'ytd')
+ *
  * Returns professional HTML report matching Statement of Account design
  */
 router.get('/budget-actual/html', authenticateUserWithProfile, async (req, res) => {
@@ -978,6 +984,7 @@ router.get('/budget-actual/html', authenticateUserWithProfile, async (req, res) 
     const clientId = req.originalParams?.clientId || req.params.clientId;
     const fiscalYear = req.query.fiscalYear ? parseInt(req.query.fiscalYear) : null;
     const language = req.query.language || 'english';
+    const reportMode = parseBudgetActualReportMode(req.query.reportMode);
     const user = req.user;
     
     if (!clientId) {
@@ -996,8 +1003,7 @@ router.get('/budget-actual/html', authenticateUserWithProfile, async (req, res) 
       });
     }
 
-    // Get budget vs actual data
-    const data = await getBudgetActualData(clientId, fiscalYear, user);
+    const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
     
     // Generate HTML
     const { html: htmlOutput } = generateBudgetActualHtml(data, { language });
@@ -1019,8 +1025,8 @@ router.get('/budget-actual/html', authenticateUserWithProfile, async (req, res) 
  * Export Budget vs Actual report
  * POST /api/clients/:clientId/reports/budget-actual/export
  * Query param: format=pdf|csv
- * Body: { fiscalYear, language, html?, meta? }
- * 
+ * Body: { fiscalYear, language, reportMode?, html?, meta? }
+ *
  * Returns PDF or CSV export of the report
  */
 router.post('/budget-actual/export', authenticateUserWithProfile, async (req, res) => {
@@ -1029,12 +1035,14 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
     const {
       fiscalYear = null,
       language = 'english',
+      reportMode: bodyReportMode,
       html,
       meta = {},
       format: bodyFormat
     } = req.body || {};
 
     const format = (req.query.format || bodyFormat || 'pdf').toLowerCase();
+    const reportMode = parseBudgetActualReportMode(bodyReportMode);
     const user = req.user;
 
     if (!clientId) {
@@ -1053,9 +1061,15 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
       });
     }
 
+    const emDash = '\u2014';
+    const csvVarianceDollars = (centavos) =>
+      centavos == null || Number.isNaN(centavos) ? emDash : centavosToPesos(centavos).toFixed(2);
+    const csvVariancePercent = (pct) =>
+      pct == null || Number.isNaN(pct) ? emDash : Number(pct).toFixed(2);
+
     // CSV export: build from data
     if (format === 'csv') {
-      const data = await getBudgetActualData(clientId, fiscalYear, user);
+      const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
       
       const header = ['Category Name', 'Type', 'Annual Budget', 'YTD Budget', 'YTD Actual', 'Variance ($)', 'Variance (%)'];
       const rows = [];
@@ -1068,8 +1082,8 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
           centavosToPesos(cat.annualBudget).toFixed(2),
           centavosToPesos(cat.ytdBudget).toFixed(2),
           centavosToPesos(cat.ytdActual).toFixed(2),
-          centavosToPesos(cat.variance).toFixed(2),
-          cat.variancePercent.toFixed(2)
+          csvVarianceDollars(cat.variance),
+          csvVariancePercent(cat.variancePercent)
         ]);
       });
 
@@ -1081,8 +1095,8 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
           centavosToPesos(cat.annualBudget).toFixed(2),
           centavosToPesos(cat.ytdBudget).toFixed(2),
           centavosToPesos(cat.ytdActual).toFixed(2),
-          centavosToPesos(cat.variance).toFixed(2),
-          cat.variancePercent.toFixed(2)
+          csvVarianceDollars(cat.variance),
+          csvVariancePercent(cat.variancePercent)
         ]);
       });
 
@@ -1174,8 +1188,7 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
     let metaToUse = meta;
 
     if (!htmlToConvert) {
-      // Generate HTML if not provided
-      const data = await getBudgetActualData(clientId, fiscalYear, user);
+      const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
       const result = generateBudgetActualHtml(data, { language });
       htmlToConvert = result.html;
       metaToUse = result.meta;

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -1110,159 +1110,100 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
       centavos == null || Number.isNaN(centavos) ? emDash : centavosToPesos(centavos).toFixed(2);
     const csvVariancePercent = (pct) =>
       pct == null || Number.isNaN(pct) ? emDash : Number(pct).toFixed(2);
-    const csvProjectedYe = (centavos) =>
-      centavos == null || Number.isNaN(centavos) ? emDash : centavosToPesos(centavos).toFixed(2);
 
     // CSV export: build from data
     if (format === 'csv') {
       const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
-      const csvProjectedLayout = data.reportInfo?.reportMode === 'projected';
 
-      const header = csvProjectedLayout
-        ? ['Category Name', 'Type', 'Annual Budget', 'Projected Year End', 'Variance ($)', 'Variance (%)']
-        : ['Category Name', 'Type', 'Annual Budget', 'YTD Budget', 'YTD Actual', 'Variance ($)', 'Variance (%)'];
+      // Same columns for ytd and projected: variance columns reflect reportMode from getBudgetActualData.
+      const header = [
+        'Category Name',
+        'Type',
+        'Annual Budget',
+        'YTD Budget',
+        'YTD Actual',
+        'Variance ($)',
+        'Variance (%)'
+      ];
       const rows = [];
 
-      if (csvProjectedLayout) {
-        data.income.categories.forEach(cat => {
-          rows.push([
-            cat.name,
-            'Income',
-            centavosToPesos(cat.annualBudget).toFixed(2),
-            csvProjectedYe(cat.projectedYearEndAmount),
-            csvVarianceDollars(cat.variance),
-            csvVariancePercent(cat.variancePercent)
-          ]);
-        });
-        data.expenses.categories.forEach(cat => {
-          rows.push([
-            cat.name,
-            'Expense',
-            centavosToPesos(cat.annualBudget).toFixed(2),
-            csvProjectedYe(cat.projectedYearEndAmount),
-            csvVarianceDollars(cat.variance),
-            csvVariancePercent(cat.variancePercent)
-          ]);
-        });
-      } else {
-        data.income.categories.forEach(cat => {
-          rows.push([
-            cat.name,
-            'Income',
-            centavosToPesos(cat.annualBudget).toFixed(2),
-            centavosToPesos(cat.ytdBudget).toFixed(2),
-            centavosToPesos(cat.ytdActual).toFixed(2),
-            csvVarianceDollars(cat.variance),
-            csvVariancePercent(cat.variancePercent)
-          ]);
-        });
-        data.expenses.categories.forEach(cat => {
-          rows.push([
-            cat.name,
-            'Expense',
-            centavosToPesos(cat.annualBudget).toFixed(2),
-            centavosToPesos(cat.ytdBudget).toFixed(2),
-            centavosToPesos(cat.ytdActual).toFixed(2),
-            csvVarianceDollars(cat.variance),
-            csvVariancePercent(cat.variancePercent)
-          ]);
-        });
-      }
+      data.income.categories.forEach(cat => {
+        rows.push([
+          cat.name,
+          'Income',
+          centavosToPesos(cat.annualBudget).toFixed(2),
+          centavosToPesos(cat.ytdBudget).toFixed(2),
+          centavosToPesos(cat.ytdActual).toFixed(2),
+          csvVarianceDollars(cat.variance),
+          csvVariancePercent(cat.variancePercent)
+        ]);
+      });
+      data.expenses.categories.forEach(cat => {
+        rows.push([
+          cat.name,
+          'Expense',
+          centavosToPesos(cat.annualBudget).toFixed(2),
+          centavosToPesos(cat.ytdBudget).toFixed(2),
+          centavosToPesos(cat.ytdActual).toFixed(2),
+          csvVarianceDollars(cat.variance),
+          csvVariancePercent(cat.variancePercent)
+        ]);
+      });
 
       // Special Assessments (as separate section)
       if (data.specialAssessments.collections && data.specialAssessments.collections.amount > 0) {
-        rows.push(
-          csvProjectedLayout
-            ? [
-                data.specialAssessments.collections.categoryName,
-                'Special Assessments - Collections',
-                '0.00',
-                centavosToPesos(data.specialAssessments.collections.amount).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-            : [
-                data.specialAssessments.collections.categoryName,
-                'Special Assessments - Collections',
-                '0.00',
-                '0.00',
-                centavosToPesos(data.specialAssessments.collections.amount).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-        );
+        rows.push([
+          data.specialAssessments.collections.categoryName,
+          'Special Assessments - Collections',
+          '0.00',
+          '0.00',
+          centavosToPesos(data.specialAssessments.collections.amount).toFixed(2),
+          '0.00',
+          '0.00'
+        ]);
       }
 
       data.specialAssessments.expenditures.forEach(exp => {
-        rows.push(
-          csvProjectedLayout
-            ? [exp.name, 'Special Assessments - Expenditure', '0.00', centavosToPesos(exp.amount).toFixed(2), '0.00', '0.00']
-            : [exp.name, 'Special Assessments - Expenditure', '0.00', '0.00', centavosToPesos(exp.amount).toFixed(2), '0.00', '0.00']
-        );
+        rows.push([
+          exp.name,
+          'Special Assessments - Expenditure',
+          '0.00',
+          '0.00',
+          centavosToPesos(exp.amount).toFixed(2),
+          '0.00',
+          '0.00'
+        ]);
       });
 
       // Unit Credit Accounts (as separate section)
       if (data.unitCreditAccounts) {
-        rows.push(
-          csvProjectedLayout
-            ? [
-                'Credit Added',
-                'Unit Credit Accounts - Added',
-                '0.00',
-                centavosToPesos(data.unitCreditAccounts.added).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-            : [
-                'Credit Added',
-                'Unit Credit Accounts - Added',
-                '0.00',
-                '0.00',
-                centavosToPesos(data.unitCreditAccounts.added).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-        );
-        rows.push(
-          csvProjectedLayout
-            ? [
-                'Credit Used',
-                'Unit Credit Accounts - Used',
-                '0.00',
-                centavosToPesos(data.unitCreditAccounts.used).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-            : [
-                'Credit Used',
-                'Unit Credit Accounts - Used',
-                '0.00',
-                '0.00',
-                centavosToPesos(data.unitCreditAccounts.used).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-        );
-        rows.push(
-          csvProjectedLayout
-            ? [
-                'Credit Balance',
-                'Unit Credit Accounts - Balance',
-                '0.00',
-                centavosToPesos(data.unitCreditAccounts.balance).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-            : [
-                'Credit Balance',
-                'Unit Credit Accounts - Balance',
-                '0.00',
-                '0.00',
-                centavosToPesos(data.unitCreditAccounts.balance).toFixed(2),
-                '0.00',
-                '0.00'
-              ]
-        );
+        rows.push([
+          'Credit Added',
+          'Unit Credit Accounts - Added',
+          '0.00',
+          '0.00',
+          centavosToPesos(data.unitCreditAccounts.added).toFixed(2),
+          '0.00',
+          '0.00'
+        ]);
+        rows.push([
+          'Credit Used',
+          'Unit Credit Accounts - Used',
+          '0.00',
+          '0.00',
+          centavosToPesos(data.unitCreditAccounts.used).toFixed(2),
+          '0.00',
+          '0.00'
+        ]);
+        rows.push([
+          'Credit Balance',
+          'Unit Credit Accounts - Balance',
+          '0.00',
+          '0.00',
+          centavosToPesos(data.unitCreditAccounts.balance).toFixed(2),
+          '0.00',
+          '0.00'
+        ]);
       }
 
       const escapeCell = (value) => {

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -1110,94 +1110,159 @@ router.post('/budget-actual/export', authenticateUserWithProfile, async (req, re
       centavos == null || Number.isNaN(centavos) ? emDash : centavosToPesos(centavos).toFixed(2);
     const csvVariancePercent = (pct) =>
       pct == null || Number.isNaN(pct) ? emDash : Number(pct).toFixed(2);
+    const csvProjectedYe = (centavos) =>
+      centavos == null || Number.isNaN(centavos) ? emDash : centavosToPesos(centavos).toFixed(2);
 
     // CSV export: build from data
     if (format === 'csv') {
       const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
-      
-      const header = ['Category Name', 'Type', 'Annual Budget', 'YTD Budget', 'YTD Actual', 'Variance ($)', 'Variance (%)'];
+      const csvProjectedLayout = data.reportInfo?.reportMode === 'projected';
+
+      const header = csvProjectedLayout
+        ? ['Category Name', 'Type', 'Annual Budget', 'Projected Year End', 'Variance ($)', 'Variance (%)']
+        : ['Category Name', 'Type', 'Annual Budget', 'YTD Budget', 'YTD Actual', 'Variance ($)', 'Variance (%)'];
       const rows = [];
 
-      // Income categories
-      data.income.categories.forEach(cat => {
-        rows.push([
-          cat.name,
-          'Income',
-          centavosToPesos(cat.annualBudget).toFixed(2),
-          centavosToPesos(cat.ytdBudget).toFixed(2),
-          centavosToPesos(cat.ytdActual).toFixed(2),
-          csvVarianceDollars(cat.variance),
-          csvVariancePercent(cat.variancePercent)
-        ]);
-      });
-
-      // Expense categories
-      data.expenses.categories.forEach(cat => {
-        rows.push([
-          cat.name,
-          'Expense',
-          centavosToPesos(cat.annualBudget).toFixed(2),
-          centavosToPesos(cat.ytdBudget).toFixed(2),
-          centavosToPesos(cat.ytdActual).toFixed(2),
-          csvVarianceDollars(cat.variance),
-          csvVariancePercent(cat.variancePercent)
-        ]);
-      });
+      if (csvProjectedLayout) {
+        data.income.categories.forEach(cat => {
+          rows.push([
+            cat.name,
+            'Income',
+            centavosToPesos(cat.annualBudget).toFixed(2),
+            csvProjectedYe(cat.projectedYearEndAmount),
+            csvVarianceDollars(cat.variance),
+            csvVariancePercent(cat.variancePercent)
+          ]);
+        });
+        data.expenses.categories.forEach(cat => {
+          rows.push([
+            cat.name,
+            'Expense',
+            centavosToPesos(cat.annualBudget).toFixed(2),
+            csvProjectedYe(cat.projectedYearEndAmount),
+            csvVarianceDollars(cat.variance),
+            csvVariancePercent(cat.variancePercent)
+          ]);
+        });
+      } else {
+        data.income.categories.forEach(cat => {
+          rows.push([
+            cat.name,
+            'Income',
+            centavosToPesos(cat.annualBudget).toFixed(2),
+            centavosToPesos(cat.ytdBudget).toFixed(2),
+            centavosToPesos(cat.ytdActual).toFixed(2),
+            csvVarianceDollars(cat.variance),
+            csvVariancePercent(cat.variancePercent)
+          ]);
+        });
+        data.expenses.categories.forEach(cat => {
+          rows.push([
+            cat.name,
+            'Expense',
+            centavosToPesos(cat.annualBudget).toFixed(2),
+            centavosToPesos(cat.ytdBudget).toFixed(2),
+            centavosToPesos(cat.ytdActual).toFixed(2),
+            csvVarianceDollars(cat.variance),
+            csvVariancePercent(cat.variancePercent)
+          ]);
+        });
+      }
 
       // Special Assessments (as separate section)
       if (data.specialAssessments.collections && data.specialAssessments.collections.amount > 0) {
-        rows.push([
-          data.specialAssessments.collections.categoryName,
-          'Special Assessments - Collections',
-          '0.00',
-          '0.00',
-          centavosToPesos(data.specialAssessments.collections.amount).toFixed(2),
-          '0.00',
-          '0.00'
-        ]);
+        rows.push(
+          csvProjectedLayout
+            ? [
+                data.specialAssessments.collections.categoryName,
+                'Special Assessments - Collections',
+                '0.00',
+                centavosToPesos(data.specialAssessments.collections.amount).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+            : [
+                data.specialAssessments.collections.categoryName,
+                'Special Assessments - Collections',
+                '0.00',
+                '0.00',
+                centavosToPesos(data.specialAssessments.collections.amount).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+        );
       }
 
       data.specialAssessments.expenditures.forEach(exp => {
-        rows.push([
-          exp.name,
-          'Special Assessments - Expenditure',
-          '0.00',
-          '0.00',
-          centavosToPesos(exp.amount).toFixed(2),
-          '0.00',
-          '0.00'
-        ]);
+        rows.push(
+          csvProjectedLayout
+            ? [exp.name, 'Special Assessments - Expenditure', '0.00', centavosToPesos(exp.amount).toFixed(2), '0.00', '0.00']
+            : [exp.name, 'Special Assessments - Expenditure', '0.00', '0.00', centavosToPesos(exp.amount).toFixed(2), '0.00', '0.00']
+        );
       });
 
       // Unit Credit Accounts (as separate section)
       if (data.unitCreditAccounts) {
-        rows.push([
-          'Credit Added',
-          'Unit Credit Accounts - Added',
-          '0.00',
-          '0.00',
-          centavosToPesos(data.unitCreditAccounts.added).toFixed(2),
-          '0.00',
-          '0.00'
-        ]);
-        rows.push([
-          'Credit Used',
-          'Unit Credit Accounts - Used',
-          '0.00',
-          '0.00',
-          centavosToPesos(data.unitCreditAccounts.used).toFixed(2),
-          '0.00',
-          '0.00'
-        ]);
-        rows.push([
-          'Credit Balance',
-          'Unit Credit Accounts - Balance',
-          '0.00',
-          '0.00',
-          centavosToPesos(data.unitCreditAccounts.balance).toFixed(2),
-          '0.00',
-          '0.00'
-        ]);
+        rows.push(
+          csvProjectedLayout
+            ? [
+                'Credit Added',
+                'Unit Credit Accounts - Added',
+                '0.00',
+                centavosToPesos(data.unitCreditAccounts.added).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+            : [
+                'Credit Added',
+                'Unit Credit Accounts - Added',
+                '0.00',
+                '0.00',
+                centavosToPesos(data.unitCreditAccounts.added).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+        );
+        rows.push(
+          csvProjectedLayout
+            ? [
+                'Credit Used',
+                'Unit Credit Accounts - Used',
+                '0.00',
+                centavosToPesos(data.unitCreditAccounts.used).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+            : [
+                'Credit Used',
+                'Unit Credit Accounts - Used',
+                '0.00',
+                '0.00',
+                centavosToPesos(data.unitCreditAccounts.used).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+        );
+        rows.push(
+          csvProjectedLayout
+            ? [
+                'Credit Balance',
+                'Unit Credit Accounts - Balance',
+                '0.00',
+                centavosToPesos(data.unitCreditAccounts.balance).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+            : [
+                'Credit Balance',
+                'Unit Credit Accounts - Balance',
+                '0.00',
+                '0.00',
+                centavosToPesos(data.unitCreditAccounts.balance).toFixed(2),
+                '0.00',
+                '0.00'
+              ]
+        );
       }
 
       const escapeCell = (value) => {

--- a/functions/backend/routes/reports.js
+++ b/functions/backend/routes/reports.js
@@ -32,7 +32,8 @@ import { centavosToPesos, roundPesos } from '../../shared/utils/currencyUtils.js
 
 /** BUDGET-PROJ-1: YTD vs projected FY-end variance basis */
 function parseBudgetActualReportMode(value) {
-  return value === 'projected' ? 'projected' : 'ytd';
+  const normalizedValue = Array.isArray(value) ? value[value.length - 1] : value;
+  return normalizedValue === 'projected' ? 'projected' : 'ytd';
 }
 
 // Create date service for formatting API responses
@@ -958,6 +959,9 @@ router.get('/budget-actual/data', authenticateUserWithProfile, async (req, res) 
     }
 
     const data = await getBudgetActualData(clientId, fiscalYear, user, { reportMode });
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
     
     res.json({ success: true, data });
   } catch (error) {
@@ -1011,6 +1015,9 @@ router.get('/budget-actual/html', authenticateUserWithProfile, async (req, res) 
     
     // Return as HTML
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
     res.send(htmlOutput);
   } catch (error) {
     logError('Error generating budget vs actual HTML:', error);

--- a/functions/backend/services/budgetActualDataService.js
+++ b/functions/backend/services/budgetActualDataService.js
@@ -592,23 +592,42 @@ export async function getBudgetActualData(clientId, fiscalYear, user, options = 
     };
 
     if (reportMode === 'projected') {
-      const sumProjected = cats =>
-        cats.reduce((sum, c) => sum + (Number(c.projectedYearEndAmount) || 0), 0);
-      incomeTotals.totalProjectedYearEnd = sumProjected(incomeCategories);
-      incomeTotals.totalVariance =
-        incomeTotals.totalProjectedYearEnd - incomeTotals.totalAnnualBudget;
-      incomeTotals.totalVariancePercent =
-        incomeTotals.totalAnnualBudget > 0
-          ? (incomeTotals.totalVariance / incomeTotals.totalAnnualBudget) * 100
-          : null;
+      // Do not treat null row projections as 0: when FY elapsed fraction is 0 (e.g. future FY),
+      // non–HOA-dues lines are null; summing them as zero would fabricate footer variance.
+      const anyRowMissingProjection = cats =>
+        cats.some(
+          c => c.projectedYearEndAmount === null || c.projectedYearEndAmount === undefined
+        );
+      const sumProjectedDefined = cats =>
+        cats.reduce((sum, c) => sum + Number(c.projectedYearEndAmount), 0);
 
-      expenseTotals.totalProjectedYearEnd = sumProjected(expenseCategories);
-      expenseTotals.totalVariance =
-        expenseTotals.totalAnnualBudget - expenseTotals.totalProjectedYearEnd;
-      expenseTotals.totalVariancePercent =
-        expenseTotals.totalAnnualBudget > 0
-          ? (expenseTotals.totalVariance / expenseTotals.totalAnnualBudget) * 100
-          : null;
+      if (anyRowMissingProjection(incomeCategories)) {
+        incomeTotals.totalProjectedYearEnd = null;
+        incomeTotals.totalVariance = null;
+        incomeTotals.totalVariancePercent = null;
+      } else {
+        incomeTotals.totalProjectedYearEnd = sumProjectedDefined(incomeCategories);
+        incomeTotals.totalVariance =
+          incomeTotals.totalProjectedYearEnd - incomeTotals.totalAnnualBudget;
+        incomeTotals.totalVariancePercent =
+          incomeTotals.totalAnnualBudget > 0
+            ? (incomeTotals.totalVariance / incomeTotals.totalAnnualBudget) * 100
+            : null;
+      }
+
+      if (anyRowMissingProjection(expenseCategories)) {
+        expenseTotals.totalProjectedYearEnd = null;
+        expenseTotals.totalVariance = null;
+        expenseTotals.totalVariancePercent = null;
+      } else {
+        expenseTotals.totalProjectedYearEnd = sumProjectedDefined(expenseCategories);
+        expenseTotals.totalVariance =
+          expenseTotals.totalAnnualBudget - expenseTotals.totalProjectedYearEnd;
+        expenseTotals.totalVariancePercent =
+          expenseTotals.totalAnnualBudget > 0
+            ? (expenseTotals.totalVariance / expenseTotals.totalAnnualBudget) * 100
+            : null;
+      }
     } else {
       const incomeAgg = computeSectionTotalVariances(
         'income',

--- a/functions/backend/services/budgetActualDataService.js
+++ b/functions/backend/services/budgetActualDataService.js
@@ -386,6 +386,27 @@ export async function getBudgetActualData(clientId, fiscalYear, user, options = 
       }
     });
 
+    /**
+     * Merge actualMap by normalized id so budget category ids match transaction keys
+     * (e.g. maintenance-elevator vs maintenance_elevator).
+     */
+    const normalizeBvACategoryKey = rawId =>
+      String(rawId || '')
+        .toLowerCase()
+        .replace(/_/g, '-');
+
+    const actualByNormalizedCategoryId = new Map();
+    for (const [key, value] of actualMap.entries()) {
+      const nk = normalizeBvACategoryKey(key);
+      actualByNormalizedCategoryId.set(
+        nk,
+        (actualByNormalizedCategoryId.get(nk) || 0) + (Number(value) || 0)
+      );
+    }
+
+    const getActualForCategory = categoryId =>
+      actualByNormalizedCategoryId.get(normalizeBvACategoryKey(categoryId)) || 0;
+
     // Helper function to check if category is a project category
     const isProjectCategory = (categoryId, categoryName) => {
       const idLower = (categoryId || '').toLowerCase();
@@ -490,7 +511,7 @@ export async function getBudgetActualData(clientId, fiscalYear, user, options = 
       
       const annualBudget = budgetMap.get(categoryId) || 0; // centavos (always positive)
       const ytdBudget = Math.round(annualBudget * (percentOfYearElapsed / 100)); // centavos (prorated, always positive)
-      const ytdActualRaw = actualMap.get(categoryId) || 0; // centavos (signed: negative for expenses, positive for income)
+      const ytdActualRaw = getActualForCategory(categoryId); // centavos (signed: negative for expenses, positive for income)
       
       // For budget comparison, we need to compare positive budget to positive actual
       // So for expenses (stored as negative), convert to positive for comparison

--- a/functions/backend/services/budgetActualDataService.js
+++ b/functions/backend/services/budgetActualDataService.js
@@ -10,15 +10,20 @@ import { getNow } from './DateService.js';
 import { getFiscalYear, getFiscalYearBounds, validateFiscalYearConfig } from '../utils/fiscalYearUtils.js';
 import { listBudgetsByYear } from '../controllers/budgetController.js';
 import { isFeatureEnabled } from '../utils/featureFlags.js';
+import {
+  computeCategoryVariances,
+  computeSectionTotalVariances
+} from '../utils/budgetActualVarianceMath.js';
 
 /**
  * Get Budget vs Actual data for a client and fiscal year
  * @param {string} clientId - Client ID
  * @param {number|null} fiscalYear - Fiscal year (null = current fiscal year)
  * @param {Object} user - User object for propertyAccess validation
+ * @param {{ reportMode?: 'ytd'|'projected' }} [options]
  * @returns {Promise<Object>} Budget vs Actual data structure
  */
-export async function getBudgetActualData(clientId, fiscalYear, user) {
+export async function getBudgetActualData(clientId, fiscalYear, user, options = {}) {
   try {
     if (!clientId || !user) {
       throw new Error('Missing required parameters: clientId or user');
@@ -60,6 +65,11 @@ export async function getBudgetActualData(clientId, fiscalYear, user) {
     const fiscalYearDuration = fiscalYearEnd - fiscalYearStart;
     const elapsedTime = Math.min(now.getTime() - fiscalYearStart, fiscalYearDuration);
     const actualPercentOfYearElapsed = Math.max(0, Math.min(100, (elapsedTime / fiscalYearDuration) * 100));
+    /** Raw FY progress 0..1 for run-rate projection only (no >95% proration). */
+    const projectionElapsedFraction =
+      fiscalYearDuration > 0 ? Math.min(1, Math.max(0, elapsedTime / fiscalYearDuration)) : 0;
+
+    const reportMode = options.reportMode === 'projected' ? 'projected' : 'ytd';
     
     // YEAR-END ADJUSTMENT: When >95% of year elapsed, treat as 100% for budget comparisons
     // This makes the report more useful for year-end reporting (final 2 weeks)
@@ -479,14 +489,15 @@ export async function getBudgetActualData(clientId, fiscalYear, user) {
         ? ytdActualRaw  // Income: already positive
         : Math.abs(ytdActualRaw); // Expense: convert negative to positive for comparison
       
-      // Context-aware variance calculation:
-      // Income: positive variance = favorable (collected more than expected)
-      // Expense: positive variance = favorable (spent less than expected)
-      const variance = categoryType === 'income'
-        ? ytdActual - ytdBudget   // Income: positive when actual > budget (good)
-        : ytdBudget - ytdActual;  // Expense: positive when budget > actual (good)
-      
-      const variancePercent = ytdBudget > 0 ? (variance / ytdBudget) * 100 : 0;
+      // Context-aware variance (YTD vs prorated budget, or projected FY-end vs annual budget)
+      const { variance, variancePercent } = computeCategoryVariances(
+        categoryType,
+        annualBudget,
+        ytdBudget,
+        ytdActual,
+        reportMode,
+        projectionElapsedFraction
+      );
 
       const categoryData = {
         id: categoryId,
@@ -495,8 +506,8 @@ export async function getBudgetActualData(clientId, fiscalYear, user) {
         annualBudget: annualBudget,
         ytdBudget: ytdBudget,
         ytdActual: ytdActual,
-        variance: variance,
-        variancePercent: variancePercent
+        variance,
+        variancePercent
       };
 
       // Categorize into three tables
@@ -544,16 +555,27 @@ export async function getBudgetActualData(clientId, fiscalYear, user) {
       balance: accountCreditBalance   // Net balance (centavos, can be positive or negative)
     };
 
-    // Calculate variance totals for each table (context-aware)
-    // Income: variance = actual - budget (positive = favorable)
-    incomeTotals.totalVariance = incomeTotals.totalYtdActual - incomeTotals.totalYtdBudget;
-    incomeTotals.totalVariancePercent = incomeTotals.totalYtdBudget > 0 
-      ? (incomeTotals.totalVariance / incomeTotals.totalYtdBudget) * 100 : 0;
+    const incomeAgg = computeSectionTotalVariances(
+      'income',
+      incomeTotals.totalAnnualBudget,
+      incomeTotals.totalYtdBudget,
+      incomeTotals.totalYtdActual,
+      reportMode,
+      projectionElapsedFraction
+    );
+    incomeTotals.totalVariance = incomeAgg.variance;
+    incomeTotals.totalVariancePercent = incomeAgg.variancePercent;
 
-    // Expense: variance = budget - actual (positive = favorable)
-    expenseTotals.totalVariance = expenseTotals.totalYtdBudget - expenseTotals.totalYtdActual;
-    expenseTotals.totalVariancePercent = expenseTotals.totalYtdBudget > 0 
-      ? (expenseTotals.totalVariance / expenseTotals.totalYtdBudget) * 100 : 0;
+    const expenseAgg = computeSectionTotalVariances(
+      'expense',
+      expenseTotals.totalAnnualBudget,
+      expenseTotals.totalYtdBudget,
+      expenseTotals.totalYtdActual,
+      reportMode,
+      projectionElapsedFraction
+    );
+    expenseTotals.totalVariance = expenseAgg.variance;
+    expenseTotals.totalVariancePercent = expenseAgg.variancePercent;
 
     // PM8B: Replace transaction-based special assessments with direct project/bill data
     const specialAssessmentsCollectionsFinal = projectCollections.length > 0
@@ -585,6 +607,8 @@ export async function getBudgetActualData(clientId, fiscalYear, user) {
         reportDate: reportDate.toISOString(),
         percentOfYearElapsed: actualPercentOfYearElapsed, // Show actual % in report info
         percentOfYearElapsedForBudget: percentOfYearElapsed, // Show adjusted % used for budget calculations
+        reportMode,
+        projectionElapsedFraction,
         reportId: reportId
       },
       income: {

--- a/functions/backend/services/budgetActualDataService.js
+++ b/functions/backend/services/budgetActualDataService.js
@@ -464,8 +464,18 @@ export async function getBudgetActualData(clientId, fiscalYear, user, options = 
       // Continue with zero values if there's an error
     }
     
-    let incomeTotals = { totalAnnualBudget: 0, totalYtdBudget: 0, totalYtdActual: 0 };
-    let expenseTotals = { totalAnnualBudget: 0, totalYtdBudget: 0, totalYtdActual: 0 };
+    let incomeTotals = {
+      totalAnnualBudget: 0,
+      totalYtdBudget: 0,
+      totalYtdActual: 0,
+      totalProjectedYearEnd: 0
+    };
+    let expenseTotals = {
+      totalAnnualBudget: 0,
+      totalYtdBudget: 0,
+      totalYtdActual: 0,
+      totalProjectedYearEnd: 0
+    };
     
     categories.forEach(category => {
       const categoryId = category.id;
@@ -489,14 +499,17 @@ export async function getBudgetActualData(clientId, fiscalYear, user, options = 
         ? ytdActualRaw  // Income: already positive
         : Math.abs(ytdActualRaw); // Expense: convert negative to positive for comparison
       
-      // Context-aware variance (YTD vs prorated budget, or projected FY-end vs annual budget)
-      const { variance, variancePercent } = computeCategoryVariances(
+      const incomeFixedAssessment =
+        categoryType === 'income' && isHOADuesCategory(categoryId) && annualBudget > 0;
+
+      const { variance, variancePercent, projectedYearEndAmount } = computeCategoryVariances(
         categoryType,
         annualBudget,
         ytdBudget,
         ytdActual,
         reportMode,
-        projectionElapsedFraction
+        projectionElapsedFraction,
+        { incomeFixedAssessment }
       );
 
       const categoryData = {
@@ -507,7 +520,9 @@ export async function getBudgetActualData(clientId, fiscalYear, user, options = 
         ytdBudget: ytdBudget,
         ytdActual: ytdActual,
         variance,
-        variancePercent
+        variancePercent,
+        projectedYearEndAmount: projectedYearEndAmount ?? null,
+        incomeFixedAssessment
       };
 
       // Categorize into three tables
@@ -555,27 +570,47 @@ export async function getBudgetActualData(clientId, fiscalYear, user, options = 
       balance: accountCreditBalance   // Net balance (centavos, can be positive or negative)
     };
 
-    const incomeAgg = computeSectionTotalVariances(
-      'income',
-      incomeTotals.totalAnnualBudget,
-      incomeTotals.totalYtdBudget,
-      incomeTotals.totalYtdActual,
-      reportMode,
-      projectionElapsedFraction
-    );
-    incomeTotals.totalVariance = incomeAgg.variance;
-    incomeTotals.totalVariancePercent = incomeAgg.variancePercent;
+    if (reportMode === 'projected') {
+      const sumProjected = cats =>
+        cats.reduce((sum, c) => sum + (Number(c.projectedYearEndAmount) || 0), 0);
+      incomeTotals.totalProjectedYearEnd = sumProjected(incomeCategories);
+      incomeTotals.totalVariance =
+        incomeTotals.totalProjectedYearEnd - incomeTotals.totalAnnualBudget;
+      incomeTotals.totalVariancePercent =
+        incomeTotals.totalAnnualBudget > 0
+          ? (incomeTotals.totalVariance / incomeTotals.totalAnnualBudget) * 100
+          : null;
 
-    const expenseAgg = computeSectionTotalVariances(
-      'expense',
-      expenseTotals.totalAnnualBudget,
-      expenseTotals.totalYtdBudget,
-      expenseTotals.totalYtdActual,
-      reportMode,
-      projectionElapsedFraction
-    );
-    expenseTotals.totalVariance = expenseAgg.variance;
-    expenseTotals.totalVariancePercent = expenseAgg.variancePercent;
+      expenseTotals.totalProjectedYearEnd = sumProjected(expenseCategories);
+      expenseTotals.totalVariance =
+        expenseTotals.totalAnnualBudget - expenseTotals.totalProjectedYearEnd;
+      expenseTotals.totalVariancePercent =
+        expenseTotals.totalAnnualBudget > 0
+          ? (expenseTotals.totalVariance / expenseTotals.totalAnnualBudget) * 100
+          : null;
+    } else {
+      const incomeAgg = computeSectionTotalVariances(
+        'income',
+        incomeTotals.totalAnnualBudget,
+        incomeTotals.totalYtdBudget,
+        incomeTotals.totalYtdActual,
+        reportMode,
+        projectionElapsedFraction
+      );
+      incomeTotals.totalVariance = incomeAgg.variance;
+      incomeTotals.totalVariancePercent = incomeAgg.variancePercent;
+
+      const expenseAgg = computeSectionTotalVariances(
+        'expense',
+        expenseTotals.totalAnnualBudget,
+        expenseTotals.totalYtdBudget,
+        expenseTotals.totalYtdActual,
+        reportMode,
+        projectionElapsedFraction
+      );
+      expenseTotals.totalVariance = expenseAgg.variance;
+      expenseTotals.totalVariancePercent = expenseAgg.variancePercent;
+    }
 
     // PM8B: Replace transaction-based special assessments with direct project/bill data
     const specialAssessmentsCollectionsFinal = projectCollections.length > 0

--- a/functions/backend/services/budgetActualHtmlService.js
+++ b/functions/backend/services/budgetActualHtmlService.js
@@ -324,7 +324,7 @@ export function generateBudgetActualHtml(data, options = {}) {
         <tr class="totals-row">
           <td class="col-category">${t.totals}</td>
           <td class="col-annual-budget">${formatCurrency(income.totals.totalAnnualBudget)}</td>
-          <td class="col-projected-ye">${formatCurrency(income.totals.totalProjectedYearEnd)}</td>
+          <td class="col-projected-ye">${formatCurrencyCell(income.totals.totalProjectedYearEnd)}</td>
           <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
           <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
         </tr>
@@ -418,7 +418,7 @@ export function generateBudgetActualHtml(data, options = {}) {
         <tr class="totals-row">
           <td class="col-category">${t.totals}</td>
           <td class="col-annual-budget">${formatCurrency(expenses.totals.totalAnnualBudget)}</td>
-          <td class="col-projected-ye">${formatCurrency(expenses.totals.totalProjectedYearEnd)}</td>
+          <td class="col-projected-ye">${formatCurrencyCell(expenses.totals.totalProjectedYearEnd)}</td>
           <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
           <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>
         </tr>

--- a/functions/backend/services/budgetActualHtmlService.js
+++ b/functions/backend/services/budgetActualHtmlService.js
@@ -196,7 +196,6 @@ function getTranslations(language) {
       tableHeaders: {
         category: 'CATEGORY NAME',
         annualBudget: 'ANNUAL BUDGET',
-        projectedYearEnd: 'PROJECTED YEAR-END',
         ytdBudget: 'YTD BUDGET',
         ytdActual: 'YTD ACTUAL',
         variance: 'VARIANCE ($)',
@@ -235,7 +234,6 @@ function getTranslations(language) {
       tableHeaders: {
         category: 'NOMBRE DE CATEGORÍA',
         annualBudget: 'PRESUPUESTO ANUAL',
-        projectedYearEnd: 'CIERRE FISCAL PROYECTADO',
         ytdBudget: 'PRESUPUESTO YTD',
         ytdActual: 'REAL YTD',
         variance: 'VARIANZA ($)',
@@ -284,61 +282,14 @@ export function generateBudgetActualHtml(data, options = {}) {
   // Get logo URL if available
   const logoUrl = clientInfo.logoUrl || null;
 
-  const isProjectedLayout = reportInfo.reportMode === 'projected';
-
-  const incomeSectionHtml = isProjectedLayout
-    ? (() => {
-        const body =
-          income.categories.length > 0
-            ? income.categories
-                .map(cat => {
-                  const varianceClass = varianceCellClass(cat.variance);
-                  return `
-        <tr>
-          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
-          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
-          <td class="col-projected-ye">${formatCurrencyCell(cat.projectedYearEndAmount)}</td>
-          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
-          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
-        </tr>`;
-                })
-                .join('')
-            : `
-        <tr>
-          <td colspan="5" style="text-align: center; padding: 20px;">${t.noData}</td>
-        </tr>`;
-        return `
-    <div class="section-header">${t.incomeTable}</div>
-    <table class="budget-table budget-table-projected">
-      <thead>
-        <tr>
-          <th class="col-category">${t.tableHeaders.category}</th>
-          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
-          <th class="col-projected-ye">${t.tableHeaders.projectedYearEnd}</th>
-          <th class="col-variance">${t.tableHeaders.variance}</th>
-          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
-        </tr>
-      </thead>
-      <tbody>${body}</tbody>
-      <tfoot>
-        <tr class="totals-row">
-          <td class="col-category">${t.totals}</td>
-          <td class="col-annual-budget">${formatCurrency(income.totals.totalAnnualBudget)}</td>
-          <td class="col-projected-ye">${formatCurrencyCell(income.totals.totalProjectedYearEnd)}</td>
-          <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
-        </tr>
-      </tfoot>
-    </table>
-    <p class="bva-footnote">${t.hoaDuesProjectedFootnote}</p>`;
-      })()
-    : (() => {
-        const body =
-          income.categories.length > 0
-            ? income.categories
-                .map(cat => {
-                  const varianceClass = varianceCellClass(cat.variance);
-                  return `
+  // BUDGET-PROJ-1 contract: projected mode uses the same six visible columns as YTD;
+  // variance ($) / (%) come from projected FY-end math (no separate Projected Year-End column).
+  const incomeBody =
+    income.categories.length > 0
+      ? income.categories
+          .map(cat => {
+            const varianceClass = varianceCellClass(cat.variance);
+            return `
         <tr>
           <td class="col-category">${translateCategoryName(cat.name, language)}</td>
           <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
@@ -347,13 +298,19 @@ export function generateBudgetActualHtml(data, options = {}) {
           <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
           <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
         </tr>`;
-                })
-                .join('')
-            : `
+          })
+          .join('')
+      : `
         <tr>
           <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
         </tr>`;
-        return `
+
+  const incomeProjectedFootnote =
+    reportInfo.reportMode === 'projected'
+      ? `<p class="bva-footnote">${t.hoaDuesProjectedFootnote}</p>`
+      : '';
+
+  const incomeSectionHtml = `
     <div class="section-header">${t.incomeTable}</div>
     <table class="budget-table">
       <thead>
@@ -366,7 +323,7 @@ export function generateBudgetActualHtml(data, options = {}) {
           <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
         </tr>
       </thead>
-      <tbody>${body}</tbody>
+      <tbody>${incomeBody}</tbody>
       <tfoot>
         <tr class="totals-row">
           <td class="col-category">${t.totals}</td>
@@ -377,61 +334,14 @@ export function generateBudgetActualHtml(data, options = {}) {
           <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
         </tr>
       </tfoot>
-    </table>`;
-      })();
+    </table>${incomeProjectedFootnote}`;
 
-  const expenseSectionHtml = isProjectedLayout
-    ? (() => {
-        const body =
-          expenses.categories.length > 0
-            ? expenses.categories
-                .map(cat => {
-                  const varianceClass = varianceCellClass(cat.variance);
-                  return `
-        <tr>
-          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
-          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
-          <td class="col-projected-ye">${formatCurrencyCell(cat.projectedYearEndAmount)}</td>
-          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
-          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
-        </tr>`;
-                })
-                .join('')
-            : `
-        <tr>
-          <td colspan="5" style="text-align: center; padding: 20px;">${t.noData}</td>
-        </tr>`;
-        return `
-    <div class="section-header">${t.expenseTable}</div>
-    <table class="budget-table budget-table-projected">
-      <thead>
-        <tr>
-          <th class="col-category">${t.tableHeaders.category}</th>
-          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
-          <th class="col-projected-ye">${t.tableHeaders.projectedYearEnd}</th>
-          <th class="col-variance">${t.tableHeaders.variance}</th>
-          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
-        </tr>
-      </thead>
-      <tbody>${body}</tbody>
-      <tfoot>
-        <tr class="totals-row">
-          <td class="col-category">${t.totals}</td>
-          <td class="col-annual-budget">${formatCurrency(expenses.totals.totalAnnualBudget)}</td>
-          <td class="col-projected-ye">${formatCurrencyCell(expenses.totals.totalProjectedYearEnd)}</td>
-          <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>
-        </tr>
-      </tfoot>
-    </table>`;
-      })()
-    : (() => {
-        const body =
-          expenses.categories.length > 0
-            ? expenses.categories
-                .map(cat => {
-                  const varianceClass = varianceCellClass(cat.variance);
-                  return `
+  const expenseBody =
+    expenses.categories.length > 0
+      ? expenses.categories
+          .map(cat => {
+            const varianceClass = varianceCellClass(cat.variance);
+            return `
         <tr>
           <td class="col-category">${translateCategoryName(cat.name, language)}</td>
           <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
@@ -440,13 +350,14 @@ export function generateBudgetActualHtml(data, options = {}) {
           <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
           <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
         </tr>`;
-                })
-                .join('')
-            : `
+          })
+          .join('')
+      : `
         <tr>
           <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
         </tr>`;
-        return `
+
+  const expenseSectionHtml = `
     <div class="section-header">${t.expenseTable}</div>
     <table class="budget-table">
       <thead>
@@ -459,7 +370,7 @@ export function generateBudgetActualHtml(data, options = {}) {
           <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
         </tr>
       </thead>
-      <tbody>${body}</tbody>
+      <tbody>${expenseBody}</tbody>
       <tfoot>
         <tr class="totals-row">
           <td class="col-category">${t.totals}</td>
@@ -471,7 +382,6 @@ export function generateBudgetActualHtml(data, options = {}) {
         </tr>
       </tfoot>
     </table>`;
-      })();
   
   // Build HTML
   const html = `<!DOCTYPE html>
@@ -634,8 +544,6 @@ export function generateBudgetActualHtml(data, options = {}) {
     .col-ytd-actual { text-align: right; width: 14%; }
     .col-variance { text-align: right; width: 14%; }
     .col-variance-percent { text-align: right; width: 14%; }
-    .col-projected-ye { text-align: right; width: 22%; }
-    .budget-table-projected .col-category { width: 30%; }
     .bva-footnote {
       font-size: 8pt;
       color: #333;

--- a/functions/backend/services/budgetActualHtmlService.js
+++ b/functions/backend/services/budgetActualHtmlService.js
@@ -196,6 +196,7 @@ function getTranslations(language) {
       tableHeaders: {
         category: 'CATEGORY NAME',
         annualBudget: 'ANNUAL BUDGET',
+        projectedYearEnd: 'PROJECTED YEAR-END',
         ytdBudget: 'YTD BUDGET',
         ytdActual: 'YTD ACTUAL',
         variance: 'VARIANCE ($)',
@@ -208,7 +209,10 @@ function getTranslations(language) {
       noData: 'No data available',
       varianceBasisCaption: 'Variance basis',
       varianceBasisYtd: 'Year-to-date (vs prorated budget)',
-      varianceBasisProjected: 'Projected fiscal year-end (run-rate vs annual budget)'
+      varianceBasisProjected:
+        'Projected year-end (HOA dues locked to annual budget; other lines run-rate vs annual)',
+      hoaDuesProjectedFootnote:
+        'HOA dues (fixed annual assessment) are shown at the budgeted year-end amount; timing differences settle across fiscal years.'
     },
     spanish: {
       title: 'REPORTE PRESUPUESTO VS REAL',
@@ -231,6 +235,7 @@ function getTranslations(language) {
       tableHeaders: {
         category: 'NOMBRE DE CATEGORÍA',
         annualBudget: 'PRESUPUESTO ANUAL',
+        projectedYearEnd: 'CIERRE FISCAL PROYECTADO',
         ytdBudget: 'PRESUPUESTO YTD',
         ytdActual: 'REAL YTD',
         variance: 'VARIANZA ($)',
@@ -243,7 +248,10 @@ function getTranslations(language) {
       noData: 'No hay datos disponibles',
       varianceBasisCaption: 'Base de varianza',
       varianceBasisYtd: 'Acumulado del año (vs presupuesto prorrateado)',
-      varianceBasisProjected: 'Cierre fiscal proyectado (ritmo vs presupuesto anual)'
+      varianceBasisProjected:
+        'Cierre fiscal proyectado (cuotas fijas al presupuesto anual; demás líneas a ritmo vs anual)',
+      hoaDuesProjectedFootnote:
+        'Las cuotas de mantenimiento (monto anual fijo) se muestran al cierre presupuestado; diferencias de calendario se liquidan entre ejercicios.'
     }
   };
   
@@ -275,6 +283,195 @@ export function generateBudgetActualHtml(data, options = {}) {
   
   // Get logo URL if available
   const logoUrl = clientInfo.logoUrl || null;
+
+  const isProjectedLayout = reportInfo.reportMode === 'projected';
+
+  const incomeSectionHtml = isProjectedLayout
+    ? (() => {
+        const body =
+          income.categories.length > 0
+            ? income.categories
+                .map(cat => {
+                  const varianceClass = varianceCellClass(cat.variance);
+                  return `
+        <tr>
+          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
+          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
+          <td class="col-projected-ye">${formatCurrencyCell(cat.projectedYearEndAmount)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
+        </tr>`;
+                })
+                .join('')
+            : `
+        <tr>
+          <td colspan="5" style="text-align: center; padding: 20px;">${t.noData}</td>
+        </tr>`;
+        return `
+    <div class="section-header">${t.incomeTable}</div>
+    <table class="budget-table budget-table-projected">
+      <thead>
+        <tr>
+          <th class="col-category">${t.tableHeaders.category}</th>
+          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
+          <th class="col-projected-ye">${t.tableHeaders.projectedYearEnd}</th>
+          <th class="col-variance">${t.tableHeaders.variance}</th>
+          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
+        </tr>
+      </thead>
+      <tbody>${body}</tbody>
+      <tfoot>
+        <tr class="totals-row">
+          <td class="col-category">${t.totals}</td>
+          <td class="col-annual-budget">${formatCurrency(income.totals.totalAnnualBudget)}</td>
+          <td class="col-projected-ye">${formatCurrency(income.totals.totalProjectedYearEnd)}</td>
+          <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
+        </tr>
+      </tfoot>
+    </table>
+    <p class="bva-footnote">${t.hoaDuesProjectedFootnote}</p>`;
+      })()
+    : (() => {
+        const body =
+          income.categories.length > 0
+            ? income.categories
+                .map(cat => {
+                  const varianceClass = varianceCellClass(cat.variance);
+                  return `
+        <tr>
+          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
+          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
+          <td class="col-ytd-budget">${formatCurrency(cat.ytdBudget)}</td>
+          <td class="col-ytd-actual">${formatCurrency(cat.ytdActual)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
+        </tr>`;
+                })
+                .join('')
+            : `
+        <tr>
+          <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
+        </tr>`;
+        return `
+    <div class="section-header">${t.incomeTable}</div>
+    <table class="budget-table">
+      <thead>
+        <tr>
+          <th class="col-category">${t.tableHeaders.category}</th>
+          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
+          <th class="col-ytd-budget">${t.tableHeaders.ytdBudget}</th>
+          <th class="col-ytd-actual">${t.tableHeaders.ytdActual}</th>
+          <th class="col-variance">${t.tableHeaders.variance}</th>
+          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
+        </tr>
+      </thead>
+      <tbody>${body}</tbody>
+      <tfoot>
+        <tr class="totals-row">
+          <td class="col-category">${t.totals}</td>
+          <td class="col-annual-budget">${formatCurrency(income.totals.totalAnnualBudget)}</td>
+          <td class="col-ytd-budget">${formatCurrency(income.totals.totalYtdBudget)}</td>
+          <td class="col-ytd-actual">${formatCurrency(income.totals.totalYtdActual)}</td>
+          <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
+        </tr>
+      </tfoot>
+    </table>`;
+      })();
+
+  const expenseSectionHtml = isProjectedLayout
+    ? (() => {
+        const body =
+          expenses.categories.length > 0
+            ? expenses.categories
+                .map(cat => {
+                  const varianceClass = varianceCellClass(cat.variance);
+                  return `
+        <tr>
+          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
+          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
+          <td class="col-projected-ye">${formatCurrencyCell(cat.projectedYearEndAmount)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
+        </tr>`;
+                })
+                .join('')
+            : `
+        <tr>
+          <td colspan="5" style="text-align: center; padding: 20px;">${t.noData}</td>
+        </tr>`;
+        return `
+    <div class="section-header">${t.expenseTable}</div>
+    <table class="budget-table budget-table-projected">
+      <thead>
+        <tr>
+          <th class="col-category">${t.tableHeaders.category}</th>
+          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
+          <th class="col-projected-ye">${t.tableHeaders.projectedYearEnd}</th>
+          <th class="col-variance">${t.tableHeaders.variance}</th>
+          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
+        </tr>
+      </thead>
+      <tbody>${body}</tbody>
+      <tfoot>
+        <tr class="totals-row">
+          <td class="col-category">${t.totals}</td>
+          <td class="col-annual-budget">${formatCurrency(expenses.totals.totalAnnualBudget)}</td>
+          <td class="col-projected-ye">${formatCurrency(expenses.totals.totalProjectedYearEnd)}</td>
+          <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>
+        </tr>
+      </tfoot>
+    </table>`;
+      })()
+    : (() => {
+        const body =
+          expenses.categories.length > 0
+            ? expenses.categories
+                .map(cat => {
+                  const varianceClass = varianceCellClass(cat.variance);
+                  return `
+        <tr>
+          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
+          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
+          <td class="col-ytd-budget">${formatCurrency(cat.ytdBudget)}</td>
+          <td class="col-ytd-actual">${formatCurrency(cat.ytdActual)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
+        </tr>`;
+                })
+                .join('')
+            : `
+        <tr>
+          <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
+        </tr>`;
+        return `
+    <div class="section-header">${t.expenseTable}</div>
+    <table class="budget-table">
+      <thead>
+        <tr>
+          <th class="col-category">${t.tableHeaders.category}</th>
+          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
+          <th class="col-ytd-budget">${t.tableHeaders.ytdBudget}</th>
+          <th class="col-ytd-actual">${t.tableHeaders.ytdActual}</th>
+          <th class="col-variance">${t.tableHeaders.variance}</th>
+          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
+        </tr>
+      </thead>
+      <tbody>${body}</tbody>
+      <tfoot>
+        <tr class="totals-row">
+          <td class="col-category">${t.totals}</td>
+          <td class="col-annual-budget">${formatCurrency(expenses.totals.totalAnnualBudget)}</td>
+          <td class="col-ytd-budget">${formatCurrency(expenses.totals.totalYtdBudget)}</td>
+          <td class="col-ytd-actual">${formatCurrency(expenses.totals.totalYtdActual)}</td>
+          <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>
+        </tr>
+      </tfoot>
+    </table>`;
+      })();
   
   // Build HTML
   const html = `<!DOCTYPE html>
@@ -437,6 +634,15 @@ export function generateBudgetActualHtml(data, options = {}) {
     .col-ytd-actual { text-align: right; width: 14%; }
     .col-variance { text-align: right; width: 14%; }
     .col-variance-percent { text-align: right; width: 14%; }
+    .col-projected-ye { text-align: right; width: 22%; }
+    .budget-table-projected .col-category { width: 30%; }
+    .bva-footnote {
+      font-size: 8pt;
+      color: #333;
+      margin: 6px 0 14px 0;
+      max-width: 8.5in;
+      line-height: 1.35;
+    }
     
     /* Variance color coding */
     .variance-favorable {
@@ -603,89 +809,9 @@ export function generateBudgetActualHtml(data, options = {}) {
     <!-- Section divider -->
     <div style="border-top: 2px solid #000; margin: 20px 0 15px 0;"></div>
     
-    <!-- Income Table -->
-    <div class="section-header">${t.incomeTable}</div>
-    <table class="budget-table">
-      <thead>
-        <tr>
-          <th class="col-category">${t.tableHeaders.category}</th>
-          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
-          <th class="col-ytd-budget">${t.tableHeaders.ytdBudget}</th>
-          <th class="col-ytd-actual">${t.tableHeaders.ytdActual}</th>
-          <th class="col-variance">${t.tableHeaders.variance}</th>
-          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
-        </tr>
-      </thead>
-      <tbody>
-        ${income.categories.length > 0 ? income.categories.map(cat => {
-          const varianceClass = varianceCellClass(cat.variance);
-          return `
-        <tr>
-          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
-          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
-          <td class="col-ytd-budget">${formatCurrency(cat.ytdBudget)}</td>
-          <td class="col-ytd-actual">${formatCurrency(cat.ytdActual)}</td>
-          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
-          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
-        </tr>`;
-        }).join('') : `
-        <tr>
-          <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
-        </tr>`}
-      </tbody>
-      <tfoot>
-        <tr class="totals-row">
-          <td class="col-category">${t.totals}</td>
-          <td class="col-annual-budget">${formatCurrency(income.totals.totalAnnualBudget)}</td>
-          <td class="col-ytd-budget">${formatCurrency(income.totals.totalYtdBudget)}</td>
-          <td class="col-ytd-actual">${formatCurrency(income.totals.totalYtdActual)}</td>
-          <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
-        </tr>
-      </tfoot>
-    </table>
+    ${incomeSectionHtml}
     
-    <!-- Expense Table -->
-    <div class="section-header">${t.expenseTable}</div>
-    <table class="budget-table">
-      <thead>
-        <tr>
-          <th class="col-category">${t.tableHeaders.category}</th>
-          <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
-          <th class="col-ytd-budget">${t.tableHeaders.ytdBudget}</th>
-          <th class="col-ytd-actual">${t.tableHeaders.ytdActual}</th>
-          <th class="col-variance">${t.tableHeaders.variance}</th>
-          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
-        </tr>
-      </thead>
-      <tbody>
-        ${expenses.categories.length > 0 ? expenses.categories.map(cat => {
-          const varianceClass = varianceCellClass(cat.variance);
-          return `
-        <tr>
-          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
-          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
-          <td class="col-ytd-budget">${formatCurrency(cat.ytdBudget)}</td>
-          <td class="col-ytd-actual">${formatCurrency(cat.ytdActual)}</td>
-          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
-          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
-        </tr>`;
-        }).join('') : `
-        <tr>
-          <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
-        </tr>`}
-      </tbody>
-      <tfoot>
-        <tr class="totals-row">
-          <td class="col-category">${t.totals}</td>
-          <td class="col-annual-budget">${formatCurrency(expenses.totals.totalAnnualBudget)}</td>
-          <td class="col-ytd-budget">${formatCurrency(expenses.totals.totalYtdBudget)}</td>
-          <td class="col-ytd-actual">${formatCurrency(expenses.totals.totalYtdActual)}</td>
-          <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>
-        </tr>
-      </tfoot>
-    </table>
+    ${expenseSectionHtml}
     
     <!-- Special Assessments Fund -->
     <div class="section-header-special">${t.specialAssessmentsTable}</div>

--- a/functions/backend/services/budgetActualHtmlService.js
+++ b/functions/backend/services/budgetActualHtmlService.js
@@ -196,6 +196,8 @@ function getTranslations(language) {
       tableHeaders: {
         category: 'CATEGORY NAME',
         annualBudget: 'ANNUAL BUDGET',
+        projectedVariance: 'PROJECTED VARIANCE ($)',
+        projectedVariancePercent: 'PROJECTED VARIANCE (%)',
         ytdBudget: 'YTD BUDGET',
         ytdActual: 'YTD ACTUAL',
         variance: 'VARIANCE ($)',
@@ -234,6 +236,8 @@ function getTranslations(language) {
       tableHeaders: {
         category: 'NOMBRE DE CATEGORÍA',
         annualBudget: 'PRESUPUESTO ANUAL',
+        projectedVariance: 'VARIANZA PROYECTADA ($)',
+        projectedVariancePercent: 'VARIANZA PROYECTADA (%)',
         ytdBudget: 'PRESUPUESTO YTD',
         ytdActual: 'REAL YTD',
         variance: 'VARIANZA ($)',
@@ -282,13 +286,22 @@ export function generateBudgetActualHtml(data, options = {}) {
   // Get logo URL if available
   const logoUrl = clientInfo.logoUrl || null;
 
-  // BUDGET-PROJ-1 contract: projected mode uses the same six visible columns as YTD;
-  // variance ($) / (%) come from projected FY-end math (no separate Projected Year-End column).
+  const isProjected = reportInfo.reportMode === 'projected';
+
   const incomeBody =
     income.categories.length > 0
       ? income.categories
           .map(cat => {
             const varianceClass = varianceCellClass(cat.variance);
+            if (isProjected) {
+              return `
+        <tr>
+          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
+          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
+        </tr>`;
+            }
             return `
         <tr>
           <td class="col-category">${translateCategoryName(cat.name, language)}</td>
@@ -302,7 +315,7 @@ export function generateBudgetActualHtml(data, options = {}) {
           .join('')
       : `
         <tr>
-          <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
+          <td colspan="${isProjected ? 4 : 6}" style="text-align: center; padding: 20px;">${t.noData}</td>
         </tr>`;
 
   const incomeProjectedFootnote =
@@ -317,10 +330,17 @@ export function generateBudgetActualHtml(data, options = {}) {
         <tr>
           <th class="col-category">${t.tableHeaders.category}</th>
           <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
+          ${
+            isProjected
+              ? `
+          <th class="col-variance">${t.tableHeaders.projectedVariance}</th>
+          <th class="col-variance-percent">${t.tableHeaders.projectedVariancePercent}</th>`
+              : `
           <th class="col-ytd-budget">${t.tableHeaders.ytdBudget}</th>
           <th class="col-ytd-actual">${t.tableHeaders.ytdActual}</th>
           <th class="col-variance">${t.tableHeaders.variance}</th>
-          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
+          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>`
+          }
         </tr>
       </thead>
       <tbody>${incomeBody}</tbody>
@@ -328,10 +348,17 @@ export function generateBudgetActualHtml(data, options = {}) {
         <tr class="totals-row">
           <td class="col-category">${t.totals}</td>
           <td class="col-annual-budget">${formatCurrency(income.totals.totalAnnualBudget)}</td>
+          ${
+            isProjected
+              ? `
+          <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>`
+              : `
           <td class="col-ytd-budget">${formatCurrency(income.totals.totalYtdBudget)}</td>
           <td class="col-ytd-actual">${formatCurrency(income.totals.totalYtdActual)}</td>
           <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
+          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>`
+          }
         </tr>
       </tfoot>
     </table>${incomeProjectedFootnote}`;
@@ -341,6 +368,15 @@ export function generateBudgetActualHtml(data, options = {}) {
       ? expenses.categories
           .map(cat => {
             const varianceClass = varianceCellClass(cat.variance);
+            if (isProjected) {
+              return `
+        <tr>
+          <td class="col-category">${translateCategoryName(cat.name, language)}</td>
+          <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
+        </tr>`;
+            }
             return `
         <tr>
           <td class="col-category">${translateCategoryName(cat.name, language)}</td>
@@ -354,7 +390,7 @@ export function generateBudgetActualHtml(data, options = {}) {
           .join('')
       : `
         <tr>
-          <td colspan="6" style="text-align: center; padding: 20px;">${t.noData}</td>
+          <td colspan="${isProjected ? 4 : 6}" style="text-align: center; padding: 20px;">${t.noData}</td>
         </tr>`;
 
   const expenseSectionHtml = `
@@ -364,10 +400,17 @@ export function generateBudgetActualHtml(data, options = {}) {
         <tr>
           <th class="col-category">${t.tableHeaders.category}</th>
           <th class="col-annual-budget">${t.tableHeaders.annualBudget}</th>
+          ${
+            isProjected
+              ? `
+          <th class="col-variance">${t.tableHeaders.projectedVariance}</th>
+          <th class="col-variance-percent">${t.tableHeaders.projectedVariancePercent}</th>`
+              : `
           <th class="col-ytd-budget">${t.tableHeaders.ytdBudget}</th>
           <th class="col-ytd-actual">${t.tableHeaders.ytdActual}</th>
           <th class="col-variance">${t.tableHeaders.variance}</th>
-          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>
+          <th class="col-variance-percent">${t.tableHeaders.variancePercent}</th>`
+          }
         </tr>
       </thead>
       <tbody>${expenseBody}</tbody>
@@ -375,10 +418,17 @@ export function generateBudgetActualHtml(data, options = {}) {
         <tr class="totals-row">
           <td class="col-category">${t.totals}</td>
           <td class="col-annual-budget">${formatCurrency(expenses.totals.totalAnnualBudget)}</td>
+          ${
+            isProjected
+              ? `
+          <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>`
+              : `
           <td class="col-ytd-budget">${formatCurrency(expenses.totals.totalYtdBudget)}</td>
           <td class="col-ytd-actual">${formatCurrency(expenses.totals.totalYtdActual)}</td>
           <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>
+          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>`
+          }
         </tr>
       </tfoot>
     </table>`;

--- a/functions/backend/services/budgetActualHtmlService.js
+++ b/functions/backend/services/budgetActualHtmlService.js
@@ -56,13 +56,29 @@ function formatDate(dateValue) {
   return dt.toFormat('dd-MMM-yy');
 }
 
-/**
- * Format percentage
- */
-function formatPercent(percent) {
-  if (!percent || isNaN(percent)) return '0.00%';
+const EM_DASH = '\u2014';
+
+/** Percent cell when backend may return null (zero denominator or undefined projection) */
+function formatPercentCell(percent) {
+  if (percent === null || percent === undefined || Number.isNaN(percent)) {
+    return EM_DASH;
+  }
   const sign = percent >= 0 ? '+' : '';
   return `${sign}${percent.toFixed(2)}%`;
+}
+
+function formatCurrencyCell(centavos, showSign = false) {
+  if (centavos === null || centavos === undefined || Number.isNaN(centavos)) {
+    return EM_DASH;
+  }
+  return formatCurrency(centavos, showSign);
+}
+
+function varianceCellClass(variance) {
+  if (variance === null || variance === undefined || Number.isNaN(variance)) {
+    return 'variance-na';
+  }
+  return variance >= 0 ? 'variance-favorable' : 'variance-unfavorable';
 }
 
 /**
@@ -189,7 +205,10 @@ function getTranslations(language) {
       totals: 'TOTALS',
       reportId: 'Report ID',
       generatedOn: 'Generated',
-      noData: 'No data available'
+      noData: 'No data available',
+      varianceBasisCaption: 'Variance basis',
+      varianceBasisYtd: 'Year-to-date (vs prorated budget)',
+      varianceBasisProjected: 'Projected fiscal year-end (run-rate vs annual budget)'
     },
     spanish: {
       title: 'REPORTE PRESUPUESTO VS REAL',
@@ -221,7 +240,10 @@ function getTranslations(language) {
       totals: 'TOTALES',
       reportId: 'ID del Reporte',
       generatedOn: 'Generado',
-      noData: 'No hay datos disponibles'
+      noData: 'No hay datos disponibles',
+      varianceBasisCaption: 'Base de varianza',
+      varianceBasisYtd: 'Acumulado del año (vs presupuesto prorrateado)',
+      varianceBasisProjected: 'Cierre fiscal proyectado (ritmo vs presupuesto anual)'
     }
   };
   
@@ -426,6 +448,10 @@ export function generateBudgetActualHtml(data, options = {}) {
       color: #C00000; /* Red */
       font-weight: bold;
     }
+    .variance-na {
+      color: #555;
+      font-weight: normal;
+    }
     
     /* Totals row */
     .totals-row {
@@ -558,6 +584,10 @@ export function generateBudgetActualHtml(data, options = {}) {
               <td>${t.percentElapsed}:</td>
               <td>${reportInfo.percentOfYearElapsed.toFixed(1)}%</td>
             </tr>
+            <tr>
+              <td>${t.varianceBasisCaption}:</td>
+              <td>${reportInfo.reportMode === 'projected' ? t.varianceBasisProjected : t.varianceBasisYtd}</td>
+            </tr>
           </table>
         </div>
       </div>
@@ -588,15 +618,15 @@ export function generateBudgetActualHtml(data, options = {}) {
       </thead>
       <tbody>
         ${income.categories.length > 0 ? income.categories.map(cat => {
-          const varianceClass = cat.variance >= 0 ? 'variance-favorable' : 'variance-unfavorable';
+          const varianceClass = varianceCellClass(cat.variance);
           return `
         <tr>
           <td class="col-category">${translateCategoryName(cat.name, language)}</td>
           <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
           <td class="col-ytd-budget">${formatCurrency(cat.ytdBudget)}</td>
           <td class="col-ytd-actual">${formatCurrency(cat.ytdActual)}</td>
-          <td class="col-variance ${varianceClass}">${formatCurrency(cat.variance, true)}</td>
-          <td class="col-variance-percent ${varianceClass}">${formatPercent(cat.variancePercent)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
         </tr>`;
         }).join('') : `
         <tr>
@@ -609,8 +639,8 @@ export function generateBudgetActualHtml(data, options = {}) {
           <td class="col-annual-budget">${formatCurrency(income.totals.totalAnnualBudget)}</td>
           <td class="col-ytd-budget">${formatCurrency(income.totals.totalYtdBudget)}</td>
           <td class="col-ytd-actual">${formatCurrency(income.totals.totalYtdActual)}</td>
-          <td class="col-variance ${income.totals.totalVariance >= 0 ? 'variance-favorable' : 'variance-unfavorable'}">${formatCurrency(income.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${income.totals.totalVariance >= 0 ? 'variance-favorable' : 'variance-unfavorable'}">${formatPercent(income.totals.totalVariancePercent)}</td>
+          <td class="col-variance ${varianceCellClass(income.totals.totalVariance)}">${formatCurrencyCell(income.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(income.totals.totalVariance)}">${formatPercentCell(income.totals.totalVariancePercent)}</td>
         </tr>
       </tfoot>
     </table>
@@ -630,15 +660,15 @@ export function generateBudgetActualHtml(data, options = {}) {
       </thead>
       <tbody>
         ${expenses.categories.length > 0 ? expenses.categories.map(cat => {
-          const varianceClass = cat.variance >= 0 ? 'variance-favorable' : 'variance-unfavorable';
+          const varianceClass = varianceCellClass(cat.variance);
           return `
         <tr>
           <td class="col-category">${translateCategoryName(cat.name, language)}</td>
           <td class="col-annual-budget">${formatCurrency(cat.annualBudget)}</td>
           <td class="col-ytd-budget">${formatCurrency(cat.ytdBudget)}</td>
           <td class="col-ytd-actual">${formatCurrency(cat.ytdActual)}</td>
-          <td class="col-variance ${varianceClass}">${formatCurrency(cat.variance, true)}</td>
-          <td class="col-variance-percent ${varianceClass}">${formatPercent(cat.variancePercent)}</td>
+          <td class="col-variance ${varianceClass}">${formatCurrencyCell(cat.variance, true)}</td>
+          <td class="col-variance-percent ${varianceClass}">${formatPercentCell(cat.variancePercent)}</td>
         </tr>`;
         }).join('') : `
         <tr>
@@ -651,8 +681,8 @@ export function generateBudgetActualHtml(data, options = {}) {
           <td class="col-annual-budget">${formatCurrency(expenses.totals.totalAnnualBudget)}</td>
           <td class="col-ytd-budget">${formatCurrency(expenses.totals.totalYtdBudget)}</td>
           <td class="col-ytd-actual">${formatCurrency(expenses.totals.totalYtdActual)}</td>
-          <td class="col-variance ${expenses.totals.totalVariance >= 0 ? 'variance-favorable' : 'variance-unfavorable'}">${formatCurrency(expenses.totals.totalVariance, true)}</td>
-          <td class="col-variance-percent ${expenses.totals.totalVariance >= 0 ? 'variance-favorable' : 'variance-unfavorable'}">${formatPercent(expenses.totals.totalVariancePercent)}</td>
+          <td class="col-variance ${varianceCellClass(expenses.totals.totalVariance)}">${formatCurrencyCell(expenses.totals.totalVariance, true)}</td>
+          <td class="col-variance-percent ${varianceCellClass(expenses.totals.totalVariance)}">${formatPercentCell(expenses.totals.totalVariancePercent)}</td>
         </tr>
       </tfoot>
     </table>

--- a/functions/backend/services/budgetActualTextService.js
+++ b/functions/backend/services/budgetActualTextService.js
@@ -163,7 +163,13 @@ function generateProjectedTableSection(title, categories, totals) {
   output += '-'.repeat(80) + '\n';
   output += 'TOTALS'.padEnd(28);
   output += formatPesos(totals.totalAnnualBudget).padStart(14);
-  output += formatPesos(totals.totalProjectedYearEnd).padStart(15);
+  const totalProjYe =
+    totals.totalProjectedYearEnd === null ||
+    totals.totalProjectedYearEnd === undefined ||
+    Number.isNaN(totals.totalProjectedYearEnd)
+      ? EM_DASH.padStart(15)
+      : formatPesos(totals.totalProjectedYearEnd).padStart(15);
+  output += totalProjYe;
 
   const totalVariance =
     totals.totalVariance === null || totals.totalVariance === undefined || Number.isNaN(totals.totalVariance)

--- a/functions/backend/services/budgetActualTextService.js
+++ b/functions/backend/services/budgetActualTextService.js
@@ -31,13 +31,17 @@ function formatPesos(centavos) {
   return pesos.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
+const EM_DASH = '\u2014';
+
 /**
  * Format percentage
- * @param {number} percent - Percentage value
- * @returns {string} Formatted percentage
+ * @param {number|null|undefined} percent - Percentage value
+ * @returns {string} Formatted percentage or em dash
  */
 function formatPercent(percent) {
-  if (!percent || isNaN(percent)) return '0.00%';
+  if (percent === null || percent === undefined || Number.isNaN(percent)) {
+    return EM_DASH;
+  }
   return `${percent.toFixed(2)}%`;
 }
 
@@ -75,10 +79,16 @@ function generateTableSection(title, categories, totals) {
     // ytdActual is already converted to positive for expenses in data service
     const ytdActual = formatPesos(category.ytdActual).padStart(15);
     
-    // Variance indicator: + for positive, - for negative
-    const varianceSign = category.variance >= 0 ? '+' : '';
-    const variance = `${varianceSign}${formatPesos(category.variance)}`.padStart(15);
-    const variancePercent = `${varianceSign}${formatPercent(category.variancePercent)}`.padStart(15);
+    const variance =
+      category.variance === null || category.variance === undefined || Number.isNaN(category.variance)
+        ? EM_DASH.padStart(15)
+        : `${category.variance >= 0 ? '+' : ''}${formatPesos(category.variance)}`.padStart(15);
+    const variancePercent =
+      category.variancePercent === null ||
+      category.variancePercent === undefined ||
+      Number.isNaN(category.variancePercent)
+        ? EM_DASH.padStart(15)
+        : `${category.variancePercent >= 0 ? '+' : ''}${formatPercent(category.variancePercent)}`.padStart(15);
     
     output += `${name}${annualBudget}${ytdBudget}${ytdActual}${variance}${variancePercent}\n`;
   });
@@ -90,9 +100,18 @@ function generateTableSection(title, categories, totals) {
   output += formatPesos(totals.totalYtdBudget).padStart(15);
   output += formatPesos(totals.totalYtdActual).padStart(15);
   
-  const totalVarianceSign = totals.totalVariance >= 0 ? '+' : '';
-  output += `${totalVarianceSign}${formatPesos(totals.totalVariance)}`.padStart(15);
-  output += `${totalVarianceSign}${formatPercent(totals.totalVariancePercent)}`.padStart(15);
+  const totalVariance =
+    totals.totalVariance === null || totals.totalVariance === undefined || Number.isNaN(totals.totalVariance)
+      ? EM_DASH.padStart(15)
+      : `${totals.totalVariance >= 0 ? '+' : ''}${formatPesos(totals.totalVariance)}`.padStart(15);
+  const totalVariancePercent =
+    totals.totalVariancePercent === null ||
+    totals.totalVariancePercent === undefined ||
+    Number.isNaN(totals.totalVariancePercent)
+      ? EM_DASH.padStart(15)
+      : `${totals.totalVariancePercent >= 0 ? '+' : ''}${formatPercent(totals.totalVariancePercent)}`.padStart(15);
+  output += totalVariance;
+  output += totalVariancePercent;
   output += '\n';
   output += '='.repeat(80) + '\n\n';
 

--- a/functions/backend/services/budgetActualTextService.js
+++ b/functions/backend/services/budgetActualTextService.js
@@ -236,6 +236,11 @@ export function generateBudgetActualText(data) {
   output += `Fiscal Year: ${reportInfo.fiscalYear}\n`;
   output += `Report Date: ${formatDate(reportInfo.reportDate)}\n`;
   output += `% of Year Elapsed: ${reportInfo.percentOfYearElapsed.toFixed(1)}%\n`;
+  const basis =
+    reportInfo.reportMode === 'projected'
+      ? 'Projected fiscal year-end (run-rate vs annual budget)'
+      : 'Year-to-date (vs prorated budget)';
+  output += `Variance basis: ${basis}\n`;
   output += '='.repeat(80) + '\n\n';
 
   // Generate three separate tables

--- a/functions/backend/services/budgetActualTextService.js
+++ b/functions/backend/services/budgetActualTextService.js
@@ -118,6 +118,71 @@ function generateTableSection(title, categories, totals) {
   return output;
 }
 
+/** Projected year-end layout: Annual, Projected Yr-End, Variance $, % */
+function generateProjectedTableSection(title, categories, totals) {
+  if (categories.length === 0) {
+    return `${title}\nNo data available\n\n`;
+  }
+
+  let output = '';
+  output += title + '\n';
+  output += '='.repeat(80) + '\n';
+
+  output += 'Category Name'.padEnd(28);
+  output += 'Annual Budget'.padStart(14);
+  output += 'Proj Yr-End'.padStart(15);
+  output += 'Variance ($)'.padStart(12);
+  output += 'Var (%)'.padStart(11);
+  output += '\n';
+  output += '-'.repeat(80) + '\n';
+
+  categories.forEach(category => {
+    const name = (category.name || category.id).substring(0, 26).padEnd(28);
+    const annualBudget = formatPesos(category.annualBudget).padStart(14);
+    const projYe =
+      category.projectedYearEndAmount === null ||
+      category.projectedYearEndAmount === undefined ||
+      Number.isNaN(category.projectedYearEndAmount)
+        ? EM_DASH.padStart(15)
+        : formatPesos(category.projectedYearEndAmount).padStart(15);
+
+    const variance =
+      category.variance === null || category.variance === undefined || Number.isNaN(category.variance)
+        ? EM_DASH.padStart(12)
+        : `${category.variance >= 0 ? '+' : ''}${formatPesos(category.variance)}`.padStart(12);
+    const variancePercent =
+      category.variancePercent === null ||
+      category.variancePercent === undefined ||
+      Number.isNaN(category.variancePercent)
+        ? EM_DASH.padStart(11)
+        : `${category.variancePercent >= 0 ? '+' : ''}${formatPercent(category.variancePercent)}`.padStart(11);
+
+    output += `${name}${annualBudget}${projYe}${variance}${variancePercent}\n`;
+  });
+
+  output += '-'.repeat(80) + '\n';
+  output += 'TOTALS'.padEnd(28);
+  output += formatPesos(totals.totalAnnualBudget).padStart(14);
+  output += formatPesos(totals.totalProjectedYearEnd).padStart(15);
+
+  const totalVariance =
+    totals.totalVariance === null || totals.totalVariance === undefined || Number.isNaN(totals.totalVariance)
+      ? EM_DASH.padStart(12)
+      : `${totals.totalVariance >= 0 ? '+' : ''}${formatPesos(totals.totalVariance)}`.padStart(12);
+  const totalVariancePercent =
+    totals.totalVariancePercent === null ||
+    totals.totalVariancePercent === undefined ||
+    Number.isNaN(totals.totalVariancePercent)
+      ? EM_DASH.padStart(11)
+      : `${totals.totalVariancePercent >= 0 ? '+' : ''}${formatPercent(totals.totalVariancePercent)}`.padStart(11);
+  output += totalVariance;
+  output += totalVariancePercent;
+  output += '\n';
+  output += '='.repeat(80) + '\n\n';
+
+  return output;
+}
+
 /**
  * Generate Special Assessments fund accounting section
  * @param {Object} specialAssessments - Special Assessments data object
@@ -236,18 +301,24 @@ export function generateBudgetActualText(data) {
   output += `Fiscal Year: ${reportInfo.fiscalYear}\n`;
   output += `Report Date: ${formatDate(reportInfo.reportDate)}\n`;
   output += `% of Year Elapsed: ${reportInfo.percentOfYearElapsed.toFixed(1)}%\n`;
-  const basis =
-    reportInfo.reportMode === 'projected'
-      ? 'Projected fiscal year-end (run-rate vs annual budget)'
-      : 'Year-to-date (vs prorated budget)';
+  const isProjected = reportInfo.reportMode === 'projected';
+  const basis = isProjected
+    ? 'Projected year-end (HOA dues locked to annual budget; other lines run-rate vs annual)'
+    : 'Year-to-date (vs prorated budget)';
   output += `Variance basis: ${basis}\n`;
   output += '='.repeat(80) + '\n\n';
 
-  // Generate three separate tables
-  output += generateTableSection('INCOME TABLE', income.categories, income.totals);
+  const incomeTable = isProjected
+    ? generateProjectedTableSection('INCOME TABLE', income.categories, income.totals)
+    : generateTableSection('INCOME TABLE', income.categories, income.totals);
+  const expenseTable = isProjected
+    ? generateProjectedTableSection('EXPENSE TABLE', expenses.categories, expenses.totals)
+    : generateTableSection('EXPENSE TABLE', expenses.categories, expenses.totals);
+
+  output += incomeTable;
   output += generateSpecialAssessmentsSection(specialAssessments);
   output += generateUnitCreditAccountsSection(unitCreditAccounts);
-  output += generateTableSection('EXPENSE TABLE', expenses.categories, expenses.totals);
+  output += expenseTable;
   
   // Footer
   output += '='.repeat(80) + '\n';

--- a/functions/backend/utils/__tests__/budgetActualVarianceMath.test.js
+++ b/functions/backend/utils/__tests__/budgetActualVarianceMath.test.js
@@ -65,6 +65,13 @@ describe('computeCategoryVariances projected', () => {
     assert.equal(r.variance, -100000000);
     assert.equal(r.variancePercent, null);
   });
+
+  it('expense: zero YTD with annual budget uses annual as projected year-end (not $0 run-rate)', () => {
+    const r = computeCategoryVariances('expense', 5000000, 2000000, 0, 'projected', 0.4);
+    assert.equal(r.projectedYearEndAmount, 5000000);
+    assert.equal(r.variance, 0);
+    assert.equal(r.variancePercent, 0);
+  });
 });
 
 describe('computeCategoryVariances ytd', () => {

--- a/functions/backend/utils/__tests__/budgetActualVarianceMath.test.js
+++ b/functions/backend/utils/__tests__/budgetActualVarianceMath.test.js
@@ -1,0 +1,65 @@
+/**
+ * Node built-in test runner (no Jest transform required for this package).
+ * Run: node --test utils/__tests__/budgetActualVarianceMath.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  projectedFYActualCentavos,
+  computeCategoryVariances,
+  computeSectionTotalVariances
+} from '../budgetActualVarianceMath.js';
+
+describe('projectedFYActualCentavos', () => {
+  it('returns null when no FY has elapsed', () => {
+    assert.equal(projectedFYActualCentavos(4000000, 0), null);
+    assert.equal(projectedFYActualCentavos(4000000, -0.1), null);
+  });
+
+  it('at 40% elapsed, scales YTD', () => {
+    assert.equal(projectedFYActualCentavos(4000000, 0.4), 10000000);
+  });
+
+  it('at or after FY end, equals YTD', () => {
+    assert.equal(projectedFYActualCentavos(9000000, 1), 9000000);
+    assert.equal(projectedFYActualCentavos(9000000, 1.2), 9000000);
+  });
+});
+
+describe('computeCategoryVariances projected', () => {
+  const frac = 0.4;
+
+  it('income: projected vs annual', () => {
+    const r = computeCategoryVariances('income', 1200000000, 480000000, 400000000, 'projected', frac);
+    assert.equal(r.variance, -200000000);
+    assert.ok(Math.abs(r.variancePercent - -100 / 6) < 0.0001);
+  });
+
+  it('expense: annual minus projected', () => {
+    const r = computeCategoryVariances('expense', 350000000, 140000000, 180000000, 'projected', frac);
+    assert.equal(r.variance, -100000000);
+    assert.ok(Math.abs(r.variancePercent - (-100000000 / 350000000) * 100) < 0.0001);
+  });
+
+  it('annual budget zero yields null percent', () => {
+    const r = computeCategoryVariances('expense', 0, 0, 40000000, 'projected', frac);
+    assert.equal(r.variance, -100000000);
+    assert.equal(r.variancePercent, null);
+  });
+});
+
+describe('computeCategoryVariances ytd', () => {
+  it('null percent when ytd budget zero', () => {
+    const r = computeCategoryVariances('expense', 0, 0, 50000, 'ytd', 0.5);
+    assert.equal(r.variance, -50000);
+    assert.equal(r.variancePercent, null);
+  });
+});
+
+describe('computeSectionTotalVariances', () => {
+  it('matches aggregate projection for income', () => {
+    const frac = 0.25;
+    const r = computeSectionTotalVariances('income', 10000000, 2500000, 2000000, 'projected', frac);
+    assert.equal(r.variance, -2000000);
+  });
+});

--- a/functions/backend/utils/__tests__/budgetActualVarianceMath.test.js
+++ b/functions/backend/utils/__tests__/budgetActualVarianceMath.test.js
@@ -31,18 +31,37 @@ describe('computeCategoryVariances projected', () => {
 
   it('income: projected vs annual', () => {
     const r = computeCategoryVariances('income', 1200000000, 480000000, 400000000, 'projected', frac);
+    assert.equal(r.projectedYearEndAmount, 1000000000);
     assert.equal(r.variance, -200000000);
     assert.ok(Math.abs(r.variancePercent - -100 / 6) < 0.0001);
   });
 
+  it('HOA dues (fixed assessment) locks projected year-end to annual budget', () => {
+    const r = computeCategoryVariances('income', 12000000, 4800000, 4000000, 'projected', 0.4, {
+      incomeFixedAssessment: true
+    });
+    assert.equal(r.projectedYearEndAmount, 12000000);
+    assert.equal(r.variance, 0);
+    assert.equal(r.variancePercent, 0);
+  });
+
+  it('fixed assessment flag ignored when annual budget is zero', () => {
+    const r = computeCategoryVariances('income', 0, 0, 4000000, 'projected', 0.4, {
+      incomeFixedAssessment: true
+    });
+    assert.equal(r.projectedYearEndAmount, 10000000);
+  });
+
   it('expense: annual minus projected', () => {
     const r = computeCategoryVariances('expense', 350000000, 140000000, 180000000, 'projected', frac);
+    assert.equal(r.projectedYearEndAmount, 450000000);
     assert.equal(r.variance, -100000000);
     assert.ok(Math.abs(r.variancePercent - (-100000000 / 350000000) * 100) < 0.0001);
   });
 
   it('annual budget zero yields null percent', () => {
     const r = computeCategoryVariances('expense', 0, 0, 40000000, 'projected', frac);
+    assert.equal(r.projectedYearEndAmount, 100000000);
     assert.equal(r.variance, -100000000);
     assert.equal(r.variancePercent, null);
   });

--- a/functions/backend/utils/budgetActualVarianceMath.js
+++ b/functions/backend/utils/budgetActualVarianceMath.js
@@ -1,0 +1,92 @@
+/**
+ * Pure helpers for Budget vs Actual variance (BUDGET-PROJ-1).
+ * Amounts are integer centavos. elapsedFraction is 0..1 from FY timing.
+ */
+
+/**
+ * @param {number} ytdActualCentavos
+ * @param {number} elapsedFraction — portion of FY elapsed (0..1), NOT the 95% prorated budget adjustment
+ * @returns {number|null} projected full-year actual in centavos, or null if undefined (no elapsed time)
+ */
+export function projectedFYActualCentavos(ytdActualCentavos, elapsedFraction) {
+  const ytd = Number(ytdActualCentavos) || 0;
+  if (elapsedFraction <= 0) {
+    return null;
+  }
+  if (elapsedFraction >= 1) {
+    return Math.round(ytd);
+  }
+  return Math.round(ytd / elapsedFraction);
+}
+
+/**
+ * @param {'income'|'expense'} categoryType
+ * @param {number} annualBudgetCentavos
+ * @param {number} ytdBudgetCentavos
+ * @param {number} ytdActualCentavos — positive magnitude for expenses
+ * @param {'ytd'|'projected'} reportMode
+ * @param {number} projectionElapsedFraction — 0..1, raw FY progress (no 95% cap)
+ * @returns {{ variance: number|null, variancePercent: number|null }}
+ */
+export function computeCategoryVariances(
+  categoryType,
+  annualBudgetCentavos,
+  ytdBudgetCentavos,
+  ytdActualCentavos,
+  reportMode,
+  projectionElapsedFraction
+) {
+  const annual = Number(annualBudgetCentavos) || 0;
+  const ytdBudget = Number(ytdBudgetCentavos) || 0;
+  const ytdActual = Number(ytdActualCentavos) || 0;
+
+  if (reportMode === 'projected') {
+    const projected = projectedFYActualCentavos(ytdActual, projectionElapsedFraction);
+    if (projected === null) {
+      return { variance: null, variancePercent: null };
+    }
+    if (categoryType === 'income') {
+      const variance = projected - annual;
+      const variancePercent = annual > 0 ? (variance / annual) * 100 : null;
+      return { variance, variancePercent };
+    }
+    const variance = annual - projected;
+    const variancePercent = annual > 0 ? (variance / annual) * 100 : null;
+    return { variance, variancePercent };
+  }
+
+  if (categoryType === 'income') {
+    const variance = ytdActual - ytdBudget;
+    const variancePercent = ytdBudget > 0 ? (variance / ytdBudget) * 100 : null;
+    return { variance, variancePercent };
+  }
+  const variance = ytdBudget - ytdActual;
+  const variancePercent = ytdBudget > 0 ? (variance / ytdBudget) * 100 : null;
+  return { variance, variancePercent };
+}
+
+/**
+ * @param {'income'|'expense'} sectionType
+ * @param {number} totalAnnualCentavos
+ * @param {number} totalYtdBudgetCentavos
+ * @param {number} totalYtdActualCentavos
+ * @param {'ytd'|'projected'} reportMode
+ * @param {number} projectionElapsedFraction
+ */
+export function computeSectionTotalVariances(
+  sectionType,
+  totalAnnualCentavos,
+  totalYtdBudgetCentavos,
+  totalYtdActualCentavos,
+  reportMode,
+  projectionElapsedFraction
+) {
+  return computeCategoryVariances(
+    sectionType,
+    totalAnnualCentavos,
+    totalYtdBudgetCentavos,
+    totalYtdActualCentavos,
+    reportMode,
+    projectionElapsedFraction
+  );
+}

--- a/functions/backend/utils/budgetActualVarianceMath.js
+++ b/functions/backend/utils/budgetActualVarianceMath.js
@@ -20,13 +20,39 @@ export function projectedFYActualCentavos(ytdActualCentavos, elapsedFraction) {
 }
 
 /**
+ * Display amount for "Projected year-end" column (centavos).
+ * HOA dues (fixed annual assessment with a budget): always annual budget — legal liability, not payment-date run-rate.
+ */
+export function projectedYearEndDisplayCentavos(
+  categoryType,
+  ytdActualCentavos,
+  annualBudgetCentavos,
+  projectionElapsedFraction,
+  options = {}
+) {
+  const { incomeFixedAssessment = false } = options;
+  const annual = Number(annualBudgetCentavos) || 0;
+  const ytdActual = Number(ytdActualCentavos) || 0;
+
+  if (
+    categoryType === 'income' &&
+    incomeFixedAssessment &&
+    annual > 0
+  ) {
+    return Math.round(annual);
+  }
+  return projectedFYActualCentavos(ytdActual, projectionElapsedFraction);
+}
+
+/**
  * @param {'income'|'expense'} categoryType
  * @param {number} annualBudgetCentavos
  * @param {number} ytdBudgetCentavos
  * @param {number} ytdActualCentavos — positive magnitude for expenses
  * @param {'ytd'|'projected'} reportMode
  * @param {number} projectionElapsedFraction — 0..1, raw FY progress (no 95% cap)
- * @returns {{ variance: number|null, variancePercent: number|null }}
+ * @param {{ incomeFixedAssessment?: boolean }} [options]
+ * @returns {{ variance: number|null, variancePercent: number|null, projectedYearEndAmount?: number|null }}
  */
 export function computeCategoryVariances(
   categoryType,
@@ -34,35 +60,48 @@ export function computeCategoryVariances(
   ytdBudgetCentavos,
   ytdActualCentavos,
   reportMode,
-  projectionElapsedFraction
+  projectionElapsedFraction,
+  options = {}
 ) {
+  const { incomeFixedAssessment = false } = options;
   const annual = Number(annualBudgetCentavos) || 0;
   const ytdBudget = Number(ytdBudgetCentavos) || 0;
   const ytdActual = Number(ytdActualCentavos) || 0;
 
   if (reportMode === 'projected') {
-    const projected = projectedFYActualCentavos(ytdActual, projectionElapsedFraction);
+    const projected = projectedYearEndDisplayCentavos(
+      categoryType,
+      ytdActual,
+      annual,
+      projectionElapsedFraction,
+      { incomeFixedAssessment }
+    );
     if (projected === null) {
-      return { variance: null, variancePercent: null };
+      return {
+        variance: null,
+        variancePercent: null,
+        projectedYearEndAmount: null
+      };
     }
     if (categoryType === 'income') {
       const variance = projected - annual;
-      const variancePercent = annual > 0 ? (variance / annual) * 100 : null;
-      return { variance, variancePercent };
+      const variancePercent =
+        annual > 0 ? (variance / annual) * 100 : null;
+      return { variance, variancePercent, projectedYearEndAmount: projected };
     }
     const variance = annual - projected;
     const variancePercent = annual > 0 ? (variance / annual) * 100 : null;
-    return { variance, variancePercent };
+    return { variance, variancePercent, projectedYearEndAmount: projected };
   }
 
   if (categoryType === 'income') {
     const variance = ytdActual - ytdBudget;
     const variancePercent = ytdBudget > 0 ? (variance / ytdBudget) * 100 : null;
-    return { variance, variancePercent };
+    return { variance, variancePercent, projectedYearEndAmount: null };
   }
   const variance = ytdBudget - ytdActual;
   const variancePercent = ytdBudget > 0 ? (variance / ytdBudget) * 100 : null;
-  return { variance, variancePercent };
+  return { variance, variancePercent, projectedYearEndAmount: null };
 }
 
 /**
@@ -79,7 +118,8 @@ export function computeSectionTotalVariances(
   totalYtdBudgetCentavos,
   totalYtdActualCentavos,
   reportMode,
-  projectionElapsedFraction
+  projectionElapsedFraction,
+  options = {}
 ) {
   return computeCategoryVariances(
     sectionType,
@@ -87,6 +127,7 @@ export function computeSectionTotalVariances(
     totalYtdBudgetCentavos,
     totalYtdActualCentavos,
     reportMode,
-    projectionElapsedFraction
+    projectionElapsedFraction,
+    options
   );
 }

--- a/functions/backend/utils/budgetActualVarianceMath.js
+++ b/functions/backend/utils/budgetActualVarianceMath.js
@@ -41,7 +41,24 @@ export function projectedYearEndDisplayCentavos(
   ) {
     return Math.round(annual);
   }
-  return projectedFYActualCentavos(ytdActual, projectionElapsedFraction);
+
+  const run = projectedFYActualCentavos(ytdActual, projectionElapsedFraction);
+  if (run === null) {
+    return null;
+  }
+
+  // Expense: pure run-rate (YTD/elapsed) yields $0 with no YTD spend — misleading when an
+  // annual budget exists (lumpy spend / timing). Assume year-end converges to the budget envelope.
+  if (categoryType === 'expense' && annual > 0 && run === 0) {
+    return Math.round(annual);
+  }
+
+  // Expense: never project below realized YTD spend (defensive vs rounding / edge timing).
+  if (categoryType === 'expense' && ytdActual > 0 && run < ytdActual) {
+    return Math.round(ytdActual);
+  }
+
+  return run;
 }
 
 /**


### PR DESCRIPTION
## Summary
Implements **BUDGET-PROJ-1** Phase B: two-way variance basis on Budget vs Actual — **YTD** (existing) vs **Projected FY-End** (run-rate vs annual budget), per design contract `.apm/BUDGET_PROJ_1_Phase_A_Design_Contract_2026-04-14.md`.

## Behavior
- **API:** `reportMode=ytd` (default) or `reportMode=projected` on `GET .../budget-actual/data` and `/html`; `POST .../budget-actual/export` accepts `reportMode` in JSON body for CSV / server-generated PDF.
- **Math:** `projectedFYActual = round(YTD / rawElapsedFraction)`; income variance `projected − annual`; expense `annual − projected`; **no** 95% proration on the projection denominator (YTD prorated budget unchanged).
- **UI:** Segmented control on `BudgetActualTab` (Variance: YTD | Projected FY-End); CSV filename includes `-projected` when applicable.
- **Display:** Em dash for null variance % (zero denominator) and for null variance $ when projection undefined (e.g. zero elapsed).

## Testing
- `cd functions/backend && node --test utils/__tests__/budgetActualVarianceMath.test.js` — pass
- ESLint on touched sams-ui files — pass
- **Manual:** AVII Reports → BvA (both modes, CSV/PDF) — pending post-merge / author smoke (Michael).

## Out of scope
Cash-health report, two-page layout, new routes (per design).

Refs: #165

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new variance mode that changes Budget vs Actual calculations, rendering, and export behavior across frontend and backend, which could affect financial report correctness and filenames. Also introduces cache-busting/no-store behavior and server-side PDF regeneration, changing request/response semantics for existing integrations.
> 
> **Overview**
> **Budget vs Actual reports now support two variance bases** via a new `reportMode` (`ytd` vs `projected`) passed through the UI, frontend `reportService`, and backend report routes.
> 
> For `projected`, the backend computes run-rate year-end projections (with special handling for HOA dues and edge cases like zero elapsed time), returns nullable variance fields, and updates HTML/text/CSV/PDF outputs to reflect the new columns/labels (including em-dash rendering for N/A). PDF export is now **always regenerated server-side** based on `reportMode`, and responses/requests add cache-busting and `no-store` to avoid stale previews/exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e2481c2cfcc086ea26b9966e22b0e347af408b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->